### PR TITLE
Fix a bug due to dangling pointer

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -187,6 +187,11 @@ LOCAL char *bytes_to_hex(uint8_t *bytes, uint32_t size);
         }                                                         \
     } while (0)
 
+/* free the object pointed by p, and set p to NULL. p must have lvalue,
+ * and should not have side-effect.
+ */
+#define C_FREE(p) { free((void*)(p)); (p) = NULL; }
+
 int MMDB_open(const char *const filename, uint32_t flags, MMDB_s *const mmdb)
 {
     mmdb->file_content = NULL;
@@ -1493,7 +1498,7 @@ LOCAL void free_mmdb_struct(MMDB_s *const mmdb)
     }
 
     if (NULL != mmdb->filename) {
-        free((void *)mmdb->filename);
+        C_FREE(mmdb->filename);
     }
     if (NULL != mmdb->file_content) {
 #ifdef _WIN32
@@ -1507,7 +1512,7 @@ LOCAL void free_mmdb_struct(MMDB_s *const mmdb)
     }
 
     if (NULL != mmdb->metadata.database_type) {
-        free((void *)mmdb->metadata.database_type);
+        C_FREE(mmdb->metadata.database_type);
     }
 
     free_languages_metadata(mmdb);
@@ -1521,9 +1526,9 @@ LOCAL void free_languages_metadata(MMDB_s *mmdb)
     }
 
     for (size_t i = 0; i < mmdb->metadata.languages.count; i++) {
-        free((char *)mmdb->metadata.languages.names[i]);
+        C_FREE(mmdb->metadata.languages.names[i]);
     }
-    free(mmdb->metadata.languages.names);
+    C_FREE(mmdb->metadata.languages.names);
 }
 
 LOCAL void free_descriptions_metadata(MMDB_s *mmdb)
@@ -1536,22 +1541,18 @@ LOCAL void free_descriptions_metadata(MMDB_s *mmdb)
         if (NULL != mmdb->metadata.description.descriptions[i]) {
             if (NULL !=
                 mmdb->metadata.description.descriptions[i]->language) {
-                free(
-                    (char *)mmdb->metadata.description.descriptions[i]->
-                    language);
+                C_FREE(mmdb->metadata.description.descriptions[i]->language);
             }
 
             if (NULL !=
                 mmdb->metadata.description.descriptions[i]->description) {
-                free(
-                    (char *)mmdb->metadata.description.descriptions[i]->
-                    description);
+                C_FREE(mmdb->metadata.description.descriptions[i]->description);
             }
-            free(mmdb->metadata.description.descriptions[i]);
+            C_FREE(mmdb->metadata.description.descriptions[i]);
         }
     }
 
-    free(mmdb->metadata.description.descriptions);
+    C_FREE(mmdb->metadata.description.descriptions);
 }
 
 const char *MMDB_lib_version(void)


### PR DESCRIPTION
  The dangling pointer could incur real problem. This is the problem I run into:
My system is runing nginx built along with ngx_http_geoip2_module and libmaxminddb.
nginx is running with a configuration with a geoip2-directive specifying a file that
dose not exist. like this:

```
-----------------------------------------------------------
geoip2 /my/path/that/dose/not/exist/maxmind-country.mmdb {
    $geoip2_data_country_code default=US country iso_code;
    $geoip2_data_country_name country names en;
}
-----------------------------------------------------------
```

  When Nginx is launched with this configuration, ngx_http_geoip2_module call
MMDB_open() which in turn calls free_mmdb_struct() as MMDB_open() was not
successfully open the specified .mmdb file.

  Nginx then exit, calling ngx_http_geoip2_cleanup() which call MMDB_close(), which
call free_mmdb_struct().

   NOTE that in this senario, free_mmdb_struct() is called _TWICE_ upon the same
mmdb! The first call to free_mmdb_struct() yields bunch of dangling pointers, and
the 2nd call to free_mmdb_struct() will call free() on these dangling pointers.

   This fix is just to set those pointer NULL right after the object they pointing
to are deallocated.
