### PR TITLE
Make sure to set pointers to NULL after freeing them

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,12 @@
 * Fixed a number of small issues found by Coverity.
 
+* When freeing the MMDB struct in `MMDB_close()` we make sure to set the
+  pointers to NULL after freeing the memory they point to. This makes it safe
+  to call `MMDB_close` more than once on the same `MMDB_s` struct
+  pointer. Before this change, calling this function twice on the same pointer
+  could cause the code to free memory that belonged to something else in the
+  process. Patch by Shuxin Yang. GitHub PR #41.
+
 ## 1.0.1 - 2014-09-03
 
 * Added missing LICENSE and NOTICE files to distribution. No code changes.

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -187,6 +187,8 @@ LOCAL char *bytes_to_hex(uint8_t *bytes, uint32_t size);
         }                                                         \
     } while (0)
 
+#define FREE_AND_SET_NULL(p) { free((void *)(p)); (p) = NULL; }
+
 int MMDB_open(const char *const filename, uint32_t flags, MMDB_s *const mmdb)
 {
     mmdb->file_content = NULL;
@@ -1499,7 +1501,7 @@ LOCAL void free_mmdb_struct(MMDB_s *const mmdb)
     }
 
     if (NULL != mmdb->filename) {
-        free((void *)mmdb->filename);
+        FREE_AND_SET_NULL(mmdb->filename);
     }
     if (NULL != mmdb->file_content) {
 #ifdef _WIN32
@@ -1513,7 +1515,7 @@ LOCAL void free_mmdb_struct(MMDB_s *const mmdb)
     }
 
     if (NULL != mmdb->metadata.database_type) {
-        free((void *)mmdb->metadata.database_type);
+        FREE_AND_SET_NULL(mmdb->metadata.database_type);
     }
 
     free_languages_metadata(mmdb);
@@ -1527,9 +1529,9 @@ LOCAL void free_languages_metadata(MMDB_s *mmdb)
     }
 
     for (size_t i = 0; i < mmdb->metadata.languages.count; i++) {
-        free((char *)mmdb->metadata.languages.names[i]);
+        FREE_AND_SET_NULL(mmdb->metadata.languages.names[i]);
     }
-    free(mmdb->metadata.languages.names);
+    FREE_AND_SET_NULL(mmdb->metadata.languages.names);
 }
 
 LOCAL void free_descriptions_metadata(MMDB_s *mmdb)
@@ -1542,22 +1544,20 @@ LOCAL void free_descriptions_metadata(MMDB_s *mmdb)
         if (NULL != mmdb->metadata.description.descriptions[i]) {
             if (NULL !=
                 mmdb->metadata.description.descriptions[i]->language) {
-                free(
-                    (char *)mmdb->metadata.description.descriptions[i]->
-                    language);
+                FREE_AND_SET_NULL(
+                    mmdb->metadata.description.descriptions[i]->language);
             }
 
             if (NULL !=
                 mmdb->metadata.description.descriptions[i]->description) {
-                free(
-                    (char *)mmdb->metadata.description.descriptions[i]->
-                    description);
+                FREE_AND_SET_NULL(
+                    mmdb->metadata.description.descriptions[i]->description);
             }
-            free(mmdb->metadata.description.descriptions[i]);
+            FREE_AND_SET_NULL(mmdb->metadata.description.descriptions[i]);
         }
     }
 
-    free(mmdb->metadata.description.descriptions);
+    FREE_AND_SET_NULL(mmdb->metadata.description.descriptions);
 }
 
 const char *MMDB_lib_version(void)


### PR DESCRIPTION
The dangling pointer could incur real problem. This is the problem I run into:
My system is runing nginx built along with ngx_http_geoip2_module and libmaxminddb.
nginx is running with a configuration with a geoip2-directive specifying a file that
dose not exist. like this:

```
-----------------------------------------------------------
geoip2 /my/path/that/dose/not/exist/maxmind-country.mmdb {
    $geoip2_data_country_code default=US country iso_code;
    $geoip2_data_country_name country names en;
}
-----------------------------------------------------------
```

When Nginx is launched with this configuration, ngx_http_geoip2_module call
MMDB_open() which in turn calls free_mmdb_struct() as MMDB_open() was not
successfully open the specified .mmdb file.

Nginx then exit, calling ngx_http_geoip2_cleanup() which call MMDB_close(), which
call free_mmdb_struct().

NOTE that in this senario, free_mmdb_struct() is called _TWICE_ upon the same
mmdb! The first call to free_mmdb_struct() yields bunch of dangling pointers, and
the 2nd call to free_mmdb_struct() will call free() on these dangling pointers.

 This fix is just to set those pointer NULL right after the object they pointing
to are deallocated.
