### PR TITLE
Correct example

### DIFF
--- a/doc/libmaxminddb.md
+++ b/doc/libmaxminddb.md
@@ -493,7 +493,6 @@ the `MMDB_lookup_string()` function.
 int mmdb_error;
 MMDB_lookup_result_s result =
     MMDB_lookup_sockaddr(mmdb, address->ai_addr, &mmdb_error);
-if (0 != gai_error) { ... }
 if (MMDB_SUCCESS != mmdb_error) { ... }
 
 if (result.found_entry) { ... }


### PR DESCRIPTION
MMDB_lookup_sockaddr() doesn't use gai_error.
