### PR TITLE
Lowercase Windows includes in order to build with MinGW on GNU/Linux

### DIFF
--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -13,8 +13,8 @@
 #include <sys/types.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
-#include <WS2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 /* libmaxminddb package version from configure */
 #define PACKAGE_VERSION "1.0.2"
 

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -10,8 +10,8 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
-#include <Windows.h>
-#include <Ws2ipdef.h>
+#include <windows.h>
+#include <ws2ipdef.h>
 #else
 #include <arpa/inet.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Since GNU/Linux filesystems are generally case-sensitive, trying to cross-compile libmaxminddb with MinGW for Windows fails since the include files can't be found because their names are lowercase.

This doesn't change anything with building it on Windows since Windows filesystems are case-insensitive, so the includes are found in both case.
