### PR TITLE
Enhancement - Check return value of CreateFileMappingA

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -281,6 +281,10 @@ LOCAL int map_file(MMDB_s *const mmdb)
         goto cleanup;
     }
     mmh = CreateFileMappingA(fd, NULL, PAGE_READONLY, 0, size, NULL);
+    if (mmh == NULL) {  /* Microsoft documentation for CreateFileMapping indicates this returns NULL not INVALID_HANDLE_VALUE on error */
+        status = MMDB_IO_ERROR;
+        goto cleanup;
+    }
     uint8_t *file_content =
         (uint8_t *)MapViewOfFile(mmh, FILE_MAP_READ, 0, 0, 0);
     if (file_content == NULL) {
@@ -318,7 +322,7 @@ LOCAL int map_file(MMDB_s *const mmdb)
     if (INVALID_HANDLE_VALUE != fd) {
         CloseHandle(fd);
     }
-    if (INVALID_HANDLE_VALUE != mmh) {
+    if (INVALID_HANDLE_VALUE != mmh && NULL != mmh) {
         CloseHandle(mmh);
     }
 #else

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -281,7 +281,7 @@ LOCAL int map_file(MMDB_s *const mmdb)
         goto cleanup;
     }
     mmh = CreateFileMappingA(fd, NULL, PAGE_READONLY, 0, size, NULL);
-    if (mmh == NULL) {  /* Microsoft documentation for CreateFileMapping indicates this returns NULL not INVALID_HANDLE_VALUE on error */
+    if (NULL == mmh) {  /* Microsoft documentation for CreateFileMapping indicates this returns NULL not INVALID_HANDLE_VALUE on error */
         status = MMDB_IO_ERROR;
         goto cleanup;
     }

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -267,7 +267,7 @@ LOCAL int map_file(MMDB_s *const mmdb)
     int status = MMDB_SUCCESS;
 #ifdef _WIN32
     HANDLE fd = INVALID_HANDLE_VALUE;
-    HANDLE mmh = INVALID_HANDLE_VALUE;
+    HANDLE mmh = NULL;
 
     fd = CreateFileA(mmdb->filename, GENERIC_READ, FILE_SHARE_READ, NULL,
                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -322,7 +322,7 @@ LOCAL int map_file(MMDB_s *const mmdb)
     if (INVALID_HANDLE_VALUE != fd) {
         CloseHandle(fd);
     }
-    if (INVALID_HANDLE_VALUE != mmh && NULL != mmh) {
+    if (NULL != mmh) {
         CloseHandle(mmh);
     }
 #else


### PR DESCRIPTION
I didn't create an issue on your side, but I can if needed (I'm still new at this and don't know proper procedures).

We had an issue on one of our live boxes where we got back MMDB_IO_ERROR on our call to MMDB_open.  Looking at the code, I noticed in map_file() that this can only be returned from a failure on MapViewOfFile (for the Windows variant).  I also noticed that CreateFileMappingA on the line above that didn't actually have its result checked.

This update checks the result of CreateFileMappingA for failure, and goes to "cleanup" on NULL.  I called CreateFileMappingA with a random number, and it did indeed return NULL and not INVALID_HANDLE_VALUE.

Anyway, this change will return immediately if the CreateFileMappingA fails, so we don't do the next line (MapViewOfFile) in that error condition.  By the way, MapViewOfFile is actually quite happy with "NULL" in mmh, which would just lead to further confusion when trying to read the data which isn't the file in that case.