### PR TITLE
Add pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /ltmain.sh
 /man
 /missing
+/src/libmaxminddb.pc
 /t/*.log
 /t/*.trs
 /t/*_t

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,10 @@ AC_INIT([libmaxminddb], [1.1.1], [support@maxmind.com])
 AC_CONFIG_SRCDIR([include/maxminddb.h])
 AC_CONFIG_HEADERS([config.h include/maxminddb_config.h])
 
+PKG_PROG_PKG_CONFIG
+m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], [AC_SUBST([pkgconfigdir], [${libdir}/pkgconfig])])
+AC_CONFIG_FILES([src/libmaxminddb.pc])
+
 LT_INIT
 AM_INIT_AUTOMAKE(foreign m4_esyscmd([case `automake --version | head -n 1` in
                                      *1.14*) echo subdir-objects;;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,3 +5,5 @@ lib_LTLIBRARIES = libmaxminddb.la
 libmaxminddb_la_SOURCES = maxminddb.c maxminddb-compat-util.h
 libmaxminddb_la_LDFLAGS = -version-info 0:7:0
 include_HEADERS = $(top_srcdir)/include/maxminddb.h
+
+pkgconfig_DATA = libmaxminddb.pc

--- a/src/libmaxminddb.pc.in
+++ b/src/libmaxminddb.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libmaxminddb
+Description: C library for the MaxMind DB file format
+URL: http://maxmind.github.io/libmaxminddb/
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lmaxminddb
+Cflags: -I${includedir}


### PR DESCRIPTION
This patch adds support for the pkg-config utility. It will make integration of the library with other projects easier by providing library version checking and required compilation flags.

Example on command line:

```
$ pkg-config --libs "libmaxminddb >= 1.1"
-L/usr/local/lib -lmaxminddb
```

Example in configure.ac:

```
PKG_CHECK_MODULES([libmaxminddb], [libmaxminddb >= 1.1])
```
