### PR TITLE
Remove unused assignment. Reorganize.

### DIFF
--- a/dev-bin/regen-prototypes.pl
+++ b/dev-bin/regen-prototypes.pl
@@ -7,6 +7,7 @@ use FindBin qw( $Bin );
 
 use File::Basename qw( basename dirname );
 use File::Slurp qw( read_file write_file );
+use List::MoreUtils qw( uniq );
 
 sub main {
     _regen_prototypes(
@@ -78,7 +79,7 @@ sub _regen_prototypes {
         $h_code =~ s{\n *(/\* \*INDENT)}{\n    $1}g;
     }
 
-    my $internal_prototypes = join q{},
+    my $internal_prototypes = join q{}, uniq
         map { $_->{prototype} . ";\n" } grep { !$_->{external} } @prototypes;
     $c_code
         =~ s/__PROTOTYPES__/$indent_off\n$prototypes_start\n$internal_prototypes$prototypes_end\n$indent_on\n/;


### PR DESCRIPTION
The Windows version of map_file shared almost no code with the
non-Windows version. Separating out the two versions of the function
completely make both of them much easier to read.