### PR TITLE
Fix several segfaults from missing bounds checks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,8 @@
 * Added pkg-config support. If your system supports it, then running `make
   install` now installs a `libmaxminddb.pc` file for pkgconfig. Implemented by
   Jan Vcelak.
+* Several segmentation faults found with afl-fuzz were fixed. These were
+  caused by missing bounds checking and missing verification of data type.
 
 ## 1.1.1 - 2015-07-22
 


### PR DESCRIPTION
These were found using afl-fuzz. There are several more similar failure
that warrant investigation. If we want to add tests, I have several
corrupt databases we could add, but these are trivially reproducible
when using the existing test databases as input to afl-fuzz.