### PR TITLE
Verify existence of metadata marker

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -365,26 +365,35 @@ LOCAL int map_file(MMDB_s *const mmdb)
 LOCAL const uint8_t *find_metadata(const uint8_t *file_content,
                                    ssize_t file_size, uint32_t *metadata_size)
 {
+    const ssize_t marker_len = sizeof(METADATA_MARKER) - 1;
     ssize_t max_size = file_size >
                        METADATA_BLOCK_MAX_SIZE ? METADATA_BLOCK_MAX_SIZE :
                        file_size;
 
     uint8_t *search_area = (uint8_t *)(file_content + (file_size - max_size));
+    uint8_t *start = search_area;
     uint8_t *tmp;
     do {
         tmp = mmdb_memmem(search_area, max_size,
-                          METADATA_MARKER, strlen(METADATA_MARKER));
+                          METADATA_MARKER, marker_len);
 
         if (NULL != tmp) {
             max_size -= tmp - search_area;
             search_area = tmp;
+
+            /* continue searching after just encountered marker */
+            max_size -= marker_len;
+            search_area += marker_len;
         }
-    } while (NULL != tmp && tmp != search_area);
+    } while (NULL != tmp);
 
-    const uint8_t *metadata_start = search_area + strlen(METADATA_MARKER);
-    *metadata_size = file_size - (search_area - file_content);
+    if (search_area == start) {
+        return NULL;
+    }
 
-    return metadata_start;
+    *metadata_size = max_size;
+
+    return search_area;
 }
 
 LOCAL int read_metadata(MMDB_s *mmdb)


### PR DESCRIPTION
The current code does not properly check if there is at least one
marker inside the database. If there is no marker available, the
initial search area will be considered as a valid metadata start,
which possibly leads to out of boundary access due to offset addition.

An example would be a database file with only one byte in it (1 byte is
needed for a successful mmap call). This statement would lead to
out of boundary access later on (file_size is 1):

    *metadata_start = search_area + strlen(METADATA_MARKER);

Also, if there are multiple markers in the metadata area, use the
last one encountered. The old code looks like that was intended.

PS: Also keep in mind that the calculation of metadata size is not
correct. The pointer increments by strlen(METADATA_MARKER),
but the size is not reduced. The later code does not keep that in
mind, therefore it should be taken into account here.