### PR TITLE
Simplify IP resolution

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+* When resolving an address, this library now relies on `getaddrinfo` to
+  determine the address family rather than trying to guess it itself.
+
 ## 1.1.4 - 2016-01-06
 
 * Packaging fixes. The 1.1.3 tarball release contained a lot of extra junk in

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+* `MMDB_lookup_sockaddr` will set `mmdb_error` to
+  `MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR` if an IPv6 `sockaddr` is looked up
+  in an IPv4-only database. Previously only `MMDB_lookup_string` would set
+  this error code.
 * When resolving an address, this library now relies on `getaddrinfo` to
   determine the address family rather than trying to guess it itself.
 

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -812,20 +812,13 @@ MMDB_lookup_result_s MMDB_lookup_string(MMDB_s *const mmdb,
 LOCAL int resolve_any_address(const char *ipstr, struct addrinfo **addresses)
 {
     struct addrinfo hints = {
+        .ai_family = AF_UNSPEC,
+        .ai_flags = AI_NUMERICHOST,
+        // We set ai_socktype so that we only get one result back
         .ai_socktype = SOCK_STREAM
     };
-    int gai_status;
 
-    if (NULL != strchr(ipstr, ':')) {
-        hints.ai_flags = AI_NUMERICHOST;
-#if defined AI_V4MAPPED && !defined __FreeBSD__
-        hints.ai_flags |= AI_V4MAPPED;
-#endif
-        hints.ai_family = AF_INET6;
-    } else {
-        hints.ai_flags = AI_NUMERICHOST;
-        hints.ai_family = AF_INET;
-    }
+    int gai_status;
 
     gai_status = getaddrinfo(ipstr, NULL, &hints, addresses);
     if (gai_status) {

--- a/t/ipv6_lookup_in_ipv4_t.c
+++ b/t/ipv6_lookup_in_ipv4_t.c
@@ -16,6 +16,26 @@ void run_tests(int mode, const char *mode_desc)
         mmdb_error, "==", MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR,
         "MMDB_lookup_string sets mmdb_error to MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR when we try to look up an IPv6 address in an IPv4-only database");
 
+    struct addrinfo hints = {
+        .ai_family = AF_INET6,
+        .ai_flags = AI_NUMERICHOST
+    };
+
+    struct addrinfo *addresses;
+    gai_error = getaddrinfo("2001:db8:85a3:0:0:8a2e:370:7334", NULL,
+                            &hints, &addresses);
+    if (gai_error) {
+        BAIL_OUT("getaddrinfo failed: %s", gai_strerror(gai_error));
+    }
+
+    mmdb_error = 0;
+    MMDB_lookup_sockaddr(mmdb, addresses->ai_addr, &mmdb_error);
+
+    cmp_ok(
+        mmdb_error, "==", MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR,
+        "MMDB_lookup_sockaddr sets mmdb_error to MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR when we try to look up an IPv6 address in an IPv4-only database");
+
+    freeaddrinfo(addresses);
     MMDB_close(mmdb);
     free(mmdb);
 }


### PR DESCRIPTION
The only plausible reason for using `getaddrinfo` over `inet_pton` is that it can detect address family. This change uses that functionality and removes some unnecessary flags. It also fixes an error so that it works with the sockaddr function.

OTOH, we could switch to `inet_pton`, but it is complicated by the fact that we made the `getaddrinfo` error part of our public interface.