### PR TITLE
Use autoconf to check system endianness rather than compiler macros

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+## 1.2.1 - ?
+
+* Use autoconf to check the system's endianness rather than trying to do this
+  with compiler-defined macros like `__BYTE_ORDER__`. Apparently this didn't
+  work properly on a Sparc system. GitHub #120.
+
+
 ## 1.2.0 - 2016-03-23
 
 * Four additional fields were added to the end of the `MMDB_search_node_s`

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,10 @@ AC_CHECK_FUNC(
         [open_memstream],
         [AC_DEFINE([HAVE_OPEN_MEMSTREAM], [1], [Has an open_memstream() function])])
 
+AC_C_BIGENDIAN(
+        [AC_DEFINE([MMDB_LITTLE_ENDIAN], [0], [System is big-endian])],
+        [AC_DEFINE([MMDB_LITTLE_ENDIAN], [1], [System is little-endian])])
+
 AC_FUNC_MALLOC
 AC_FUNC_MMAP
 

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1744,7 +1744,9 @@ LOCAL float get_ieee754_float(const uint8_t *restrict p)
 {
     volatile float f;
     uint8_t *q = (void *)&f;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+/* Windows builds don't use autoconf but we can assume they're all
+ * little-endian. */
+#if MMDB_LITTLE_ENDIAN || _WIN32
     q[3] = p[0];
     q[2] = p[1];
     q[1] = p[2];
@@ -1759,7 +1761,7 @@ LOCAL double get_ieee754_double(const uint8_t *restrict p)
 {
     volatile double d;
     uint8_t *q = (void *)&d;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#if MMDB_LITTLE_ENDIAN || _WIN32
     q[7] = p[0];
     q[6] = p[1];
     q[5] = p[2];


### PR DESCRIPTION
Hopefully this will fix https://github.com/maxmind/libmaxminddb/issues/120
(breakage on Sparc systems).