### PR TITLE
Fix overflow in bound checks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,10 @@
   work properly on a Sparc system. GitHub #120.
 * Several compiler warnings on Visual C++ were fixed. Pull request by Marcel
   Raad. GitHub #130.
+* Fix segmentation faults found in `MMDB_open()` using afl-fuzz. This
+  occurred on corrupt databases that had a data pointer large enough to
+  cause an integer overflow when doing bound checking. Reported by Ryan
+  Whitworth. GitHub #140.
 
 
 ## 1.2.0 - 2016-03-23

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ test_script:
   - .\projects\VS12\Debug\test_get_value.exe
   - .\projects\VS12\Debug\test_ipv4_start_cache.exe
   - .\projects\VS12\Debug\test_ipv6_lookup_in_ipv4.exe
+  - .\projects\VS12\Debug\test_metadata_pointers.exe
   - .\projects\VS12\Debug\test_metadata.exe
   - .\projects\VS12\Debug\test_no_map_get_value.exe
   - .\projects\VS12\Debug\test_read_node.exe

--- a/dev-bin/regen-prototypes.pl
+++ b/dev-bin/regen-prototypes.pl
@@ -90,7 +90,6 @@ sub _regen_prototypes {
 
 my $return_type_re = qr/(?:\w+\s+)+?\**?/;
 my $signature_re   = qr/\([^\(\)]+?\)/;
-my $c_function_re  = qr/($return_type_re(\w+)$signature_re)(?>\n{)/s;
 
 # Shamelessly stolen from Inline::C::ParseRegExp
 my $sp = qr{[ \t]|\n(?![ \t]*\n)};

--- a/projects/VS12-tests/bad_pointers.vcxproj
+++ b/projects/VS12-tests/bad_pointers.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11BAF4-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B19839F4-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bad_pointers</RootNamespace>
     <ProjectName>test_bad_pointers</ProjectName>

--- a/projects/VS12-tests/basic_lookup.vcxproj
+++ b/projects/VS12-tests/basic_lookup.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11C512-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1983C10-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>basic_lookup</RootNamespace>
     <ProjectName>test_basic_lookup</ProjectName>

--- a/projects/VS12-tests/data_entry_list.vcxproj
+++ b/projects/VS12-tests/data_entry_list.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11C882-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1983E90-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>data_entry_list</RootNamespace>
     <ProjectName>test_data_entry_list</ProjectName>

--- a/projects/VS12-tests/dump.vcxproj
+++ b/projects/VS12-tests/dump.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11CEEA-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984188-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dump</RootNamespace>
     <ProjectName>test_dump</ProjectName>

--- a/projects/VS12-tests/get_value.vcxproj
+++ b/projects/VS12-tests/get_value.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11D5E8-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984480-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>get_value</RootNamespace>
     <ProjectName>test_get_value</ProjectName>

--- a/projects/VS12-tests/get_value_pointer_bug.vcxproj
+++ b/projects/VS12-tests/get_value_pointer_bug.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11D2AA-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984304-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>get_value_pointer_bug</RootNamespace>
     <ProjectName>test_get_value_pointer_bug</ProjectName>

--- a/projects/VS12-tests/ipv4_start_cache.vcxproj
+++ b/projects/VS12-tests/ipv4_start_cache.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11D930-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B198466A-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ipv4_start_cache</RootNamespace>
     <ProjectName>test_ipv4_start_cache</ProjectName>

--- a/projects/VS12-tests/ipv6_lookup_in_ipv4.vcxproj
+++ b/projects/VS12-tests/ipv6_lookup_in_ipv4.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11DC64-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984872-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ipv6_lookup_in_ipv4</RootNamespace>
     <ProjectName>test_ipv6_lookup_in_ipv4</ProjectName>

--- a/projects/VS12-tests/metadata.vcxproj
+++ b/projects/VS12-tests/metadata.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11DFC0-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984C6E-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>metadata</RootNamespace>
     <ProjectName>test_metadata</ProjectName>

--- a/projects/VS12-tests/metadata_pointers.vcxproj
+++ b/projects/VS12-tests/metadata_pointers.vcxproj
@@ -11,10 +11,10 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{B198400C-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
+    <ProjectGuid>{B19849D0-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>data_types</RootNamespace>
-    <ProjectName>test_data_types</ProjectName>
+    <RootNamespace>metadata_pointers</RootNamespace>
+    <ProjectName>test_metadata_pointers</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -81,7 +81,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\t\data_types_t.c" />
+    <ClCompile Include="..\..\t\metadata_pointers_t.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="libtap.vcxproj">

--- a/projects/VS12-tests/no_map_get_value.vcxproj
+++ b/projects/VS12-tests/no_map_get_value.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11E33A-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B1984EC6-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>no_map_get_value</RootNamespace>
     <ProjectName>test_no_map_get_value</ProjectName>

--- a/projects/VS12-tests/read_node.vcxproj
+++ b/projects/VS12-tests/read_node.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11E68C-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B198504C-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>read_node</RootNamespace>
     <ProjectName>test_read_node</ProjectName>

--- a/projects/VS12-tests/version.vcxproj
+++ b/projects/VS12-tests/version.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8E11ED26-7B63-11E4-AE98-6B41E8A9DDB2}</ProjectGuid>
+    <ProjectGuid>{B19851FA-376C-11E7-A95B-48C58C130AD6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>version</RootNamespace>
     <ProjectName>test_version</ProjectName>

--- a/projects/VS12/libmaxminddb.sln
+++ b/projects/VS12/libmaxminddb.sln
@@ -35,6 +35,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_version", "..\VS12-tes
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_bad_pointers", "..\VS12-tests\bad_pointers.vcxproj", "{8E11BAF4-7B63-11E4-AE98-6B41E8A9DDB2}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_metadata_pointers", "..\VS12-tests\metadata_pointers.vcxproj", "{8E11CBD4-7B63-11E4-AE98-6B41E8A9DDB2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -283,6 +283,16 @@ int MMDB_open(const char *const filename, uint32_t flags, MMDB_s *const mmdb)
     }
     mmdb->data_section_size = (uint32_t)mmdb->file_size - search_tree_size -
                               MMDB_DATA_SECTION_SEPARATOR;
+
+    // Although it is likely not possible to construct a database with valid
+    // valid metadata, as parsed above, and a data_section_size less than 3,
+    // we do this check as later we assume it is at least three when doing
+    // bound checks.
+    if (mmdb->data_section_size < 3) {
+        status = MMDB_INVALID_DATA_ERROR;
+        goto cleanup;
+    }
+
     mmdb->metadata_section = metadata;
     mmdb->ipv4_start_node.node_value = 0;
     mmdb->ipv4_start_node.netmask = 0;

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1384,7 +1384,10 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
 {
     const uint8_t *mem = mmdb->data_section;
 
-    if (offset + 1 > mmdb->data_section_size) {
+    // We subtract rather than add as it possible that offset + 1
+    // could overflow for a corrupt database while an underflow
+    // from data_section_size - 1 should not be possible.
+    if (offset > mmdb->data_section_size - 1) {
         DEBUG_MSGF("Offset (%d) past data section (%d)", offset,
                    mmdb->data_section_size);
         return MMDB_INVALID_DATA_ERROR;
@@ -1403,7 +1406,8 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
     DEBUG_MSGF("Type: %i (%s)", type, type_num_to_name(type));
 
     if (type == MMDB_DATA_TYPE_EXTENDED) {
-        if (offset + 1 > mmdb->data_section_size) {
+        // Subtracting 1 to avoid possible overflow on offset + 1
+        if (offset > mmdb->data_section_size - 1) {
             DEBUG_MSGF("Extended type offset (%d) past data section (%d)",
                        offset,
                        mmdb->data_section_size);
@@ -1416,10 +1420,13 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
     entry_data->type = type;
 
     if (type == MMDB_DATA_TYPE_POINTER) {
-        int psize = ((ctrl >> 3) & 3) + 1;
+        uint8_t psize = ((ctrl >> 3) & 3) + 1;
         DEBUG_MSGF("Pointer size: %i", psize);
 
-        if (offset + psize > mmdb->data_section_size) {
+        // We check that the offset does not extend past the end of the
+        // database and that the subtraction of psize did not underflow.
+        if (offset > mmdb->data_section_size - psize ||
+            mmdb->data_section_size < psize) {
             DEBUG_MSGF("Pointer offset (%d) past data section (%d)", offset +
                        psize,
                        mmdb->data_section_size);
@@ -1436,7 +1443,8 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
     uint32_t size = ctrl & 31;
     switch (size) {
     case 29:
-        if (offset + 1 > mmdb->data_section_size) {
+        // We subtract when checking offset to avoid possible overflow
+        if (offset > mmdb->data_section_size - 1) {
             DEBUG_MSGF("String end (%d, case 29) past data section (%d)",
                        offset,
                        mmdb->data_section_size);
@@ -1445,7 +1453,8 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
         size = 29 + mem[offset++];
         break;
     case 30:
-        if (offset + 2 > mmdb->data_section_size) {
+        // We subtract when checking offset to avoid possible overflow
+        if (offset > mmdb->data_section_size - 2) {
             DEBUG_MSGF("String end (%d, case 30) past data section (%d)",
                        offset,
                        mmdb->data_section_size);
@@ -1455,7 +1464,8 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
         offset += 2;
         break;
     case 31:
-        if (offset + 3 > mmdb->data_section_size) {
+        // We subtract when checking offset to avoid possible overflow
+        if (offset > mmdb->data_section_size - 3) {
             DEBUG_MSGF("String end (%d, case 31) past data section (%d)",
                        offset,
                        mmdb->data_section_size);
@@ -1483,9 +1493,10 @@ LOCAL int decode_one(MMDB_s *mmdb, uint32_t offset,
         return MMDB_SUCCESS;
     }
 
-    // check that the data doesn't extend past the end of the memory
-    // buffer
-    if (offset + size > mmdb->data_section_size) {
+    // Check that the data doesn't extend past the end of the memory
+    // buffer and that the calculation in doing this did not underflow.
+    if (offset > mmdb->data_section_size - size ||
+        mmdb->data_section_size < size) {
         DEBUG_MSGF("Data end (%d) past data section (%d)", offset + size,
                    mmdb->data_section_size);
         return MMDB_INVALID_DATA_ERROR;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -11,9 +11,9 @@ noinst_LTLIBRARIES = libmmdbtest.la
 libmmdbtest_la_SOURCES = maxminddb_test_helper.c
 
 check_PROGRAMS = \
-	bad_pointers_t basic_lookup_t data_entry_list_t data_types_t \
-	dump_t get_value_t get_value_pointer_bug_t ipv4_start_cache_t \
-	ipv6_lookup_in_ipv4_t metadata_t metadata_pointers_t          \
+	bad_pointers_t bad_databases_t basic_lookup_t data_entry_list_t \
+    data_types_t dump_t get_value_t get_value_pointer_bug_t \
+	ipv4_start_cache_t ipv6_lookup_in_ipv4_t metadata_t metadata_pointers_t \
 	no_map_get_value_t read_node_t threads_t version_t
 
 threads_t_CFLAGS = $(CFLAGS) -pthread

--- a/t/bad_databases_t.c
+++ b/t/bad_databases_t.c
@@ -1,0 +1,65 @@
+#define _XOPEN_SOURCE 500
+#include <ftw.h>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <libgen.h>
+#include <unistd.h>
+#endif
+
+#include "maxminddb_test_helper.h"
+
+int test_read(const char *path, const struct stat *UNUSED(
+                  sbuf), int flags, struct FTW *UNUSED(ftw))
+{
+    // Check if path is a regular file)
+    if (flags != FTW_F) {
+        return 0;
+    }
+
+    MMDB_s *mmdb = (MMDB_s *)calloc(1, sizeof(MMDB_s));
+
+    if (NULL == mmdb) {
+        BAIL_OUT("could not allocate memory for our MMDB_s struct");
+    }
+
+    int status = MMDB_open(path, MMDB_MODE_MMAP, mmdb);
+
+    if (status != MMDB_SUCCESS) {
+        ok(1, "received error when opening %s", path);
+        return 0;
+    }
+
+    int gai_error, mmdb_error;
+    MMDB_lookup_string(mmdb, "ip", &gai_error, &mmdb_error);
+
+    cmp_ok(mmdb_error, "!=", MMDB_SUCCESS, "opening %s returned an error",
+           path);
+
+    MMDB_close(mmdb);
+    free(mmdb);
+    return 0;
+}
+
+int main(void)
+{
+    char *test_db_dir;
+#ifdef _WIN32
+    test_db_dir = "./t/maxmind-db/bad-data";
+#else
+    char cwd[500];
+    char *UNUSED(tmp) = getcwd(cwd, 500);
+
+    if (strcmp(basename(cwd), "t") == 0) {
+        test_db_dir = "./maxmind-db/bad-data";
+    } else {
+        test_db_dir = "./t/maxmind-db/bad-data";
+    }
+#endif
+    plan(NO_PLAN);
+    if (nftw(test_db_dir, test_read, 10, FTW_PHYS) != 0) {
+        BAIL_OUT("nftw failed");
+    }
+    done_testing();
+}

--- a/t/bad_databases_t.c
+++ b/t/bad_databases_t.c
@@ -1,12 +1,10 @@
+// This test currently does not work on Windows as nftw is
+// not available.
 #define _XOPEN_SOURCE 500
 #include <ftw.h>
 
-#ifdef _WIN32
-#include <io.h>
-#else
 #include <libgen.h>
 #include <unistd.h>
-#endif
 
 #include "maxminddb_test_helper.h"
 

--- a/t/get_value_t.c
+++ b/t/get_value_t.c
@@ -54,7 +54,8 @@ void test_simple_structure(int mode, const char *mode_desc)
         status = MMDB_get_value(&result.entry, &entry_data, "array", "0", NULL);
         test_array_0_result(status, entry_data, "MMDB_get_value");
 
-        status = call_vget_value(&result.entry, &entry_data, "array", "0", NULL);
+        status =
+            call_vget_value(&result.entry, &entry_data, "array", "0", NULL);
         test_array_0_result(status, entry_data, "MMDB_vget_value");
     }
 
@@ -67,7 +68,8 @@ void test_simple_structure(int mode, const char *mode_desc)
         status = MMDB_get_value(&result.entry, &entry_data, "array", "2", NULL);
         test_array_2_result(status, entry_data, "MMDB_get_value");
 
-        status = call_vget_value(&result.entry, &entry_data, "array", "2", NULL);
+        status =
+            call_vget_value(&result.entry, &entry_data, "array", "2", NULL);
         test_array_2_result(status, entry_data, "MMDB_vget_value");
     }
 
@@ -159,7 +161,8 @@ void test_nested_structure(int mode, const char *mode_desc)
         test_complex_map_a_result(status, entry_data, "MMDB_aget_value");
 
         status = MMDB_get_value(&result.entry, &entry_data,
-                                "map1", "map2", "array", "0", "map3", "a", NULL);
+                                "map1", "map2", "array", "0", "map3", "a",
+                                NULL);
         test_complex_map_a_result(status, entry_data, "MMDB_get_value");
 
         status = call_vget_value(&result.entry, &entry_data,
@@ -176,7 +179,8 @@ void test_nested_structure(int mode, const char *mode_desc)
         test_complex_map_c_result(status, entry_data, "MMDB_aget_value");
 
         status = MMDB_get_value(&result.entry, &entry_data,
-                                "map1", "map2", "array", "0", "map3", "c", NULL);
+                                "map1", "map2", "array", "0", "map3", "c",
+                                NULL);
         test_complex_map_c_result(status, entry_data, "MMDB_get_value");
 
         status = call_vget_value(&result.entry, &entry_data,

--- a/t/maxminddb_test_helper.h
+++ b/t/maxminddb_test_helper.h
@@ -1,5 +1,5 @@
 /* Some test files may require something newer */
-#ifndef _GNU_SOURCE
+#if !defined(_GNU_SOURCE) && !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
 #endif
 


### PR DESCRIPTION
A corrupt database could cause a segmentation fault if it had a data
pointer large enough to cause an overflow in the existing bound checks.

Fixes #140.