### PR TITLE
Fix wrong epoch formatting for verbose mmdblookup

### DIFF
--- a/bin/mmdblookup.c
+++ b/bin/mmdblookup.c
@@ -229,8 +229,8 @@ LOCAL void dump_meta(MMDB_s *mmdb)
                             "    Languages:     ";
 
     char date[40];
-    strftime(date, 40, "%F %T UTC",
-             gmtime((const time_t *)&mmdb->metadata.build_epoch));
+    const time_t epoch = (const time_t)mmdb->metadata.build_epoch;
+    strftime(date, 40, "%F %T UTC", gmtime(&epoch));
 
     fprintf(stdout, meta_dump,
             mmdb->metadata.node_count,


### PR DESCRIPTION
(at least on 32 bit builds on Solaris Sparc).

Verbose mmdblookup output before the fix:
   Build epoch:   1497876636 (1970-01-01 00:00:00 UTC)
and after the fix:
   Build epoch:   1497876636 (2017-06-19 12:50:36 UTC)

The original code converted *uint64_t to *time_t by casting
the pointer. But that doesn't convert the referenced value
and for a build where a time_t is a long of size 32bits
(eg. on Solaris Sparc) probably also depending on endianess
when dereferencing the casted pointer you get the wrong half
of the 64 bits (=0).

The fix is to cast the value and use a pointer to the casted value.