### PR TITLE
Set the last element in the list's next pointer to NULL

### DIFF
--- a/src/data-pool.c
+++ b/src/data-pool.c
@@ -122,7 +122,7 @@ MMDB_entry_data_list_s *data_pool_to_list(MMDB_data_pool_s *const pool)
         cur->next = pool->data + i + 1;
     }
 
-    MMDB_entry_data_list_s *const last = pool->data + pool->used_size;
+    MMDB_entry_data_list_s *const last = pool->data + pool->used_size - 1;
     last->next = NULL;
 
     return pool->data;

--- a/t/data-pool-t.c
+++ b/t/data-pool-t.c
@@ -162,4 +162,53 @@ static void test_data_pool_to_list(void)
 
         data_pool_destroy(pool);
     }
+
+    {
+        size_t const initial_size = 1;
+        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
+        ok(pool != NULL, "created pool");
+
+        MMDB_entry_data_list_s *const list_empty = data_pool_to_list(pool);
+        ok(list_empty == NULL, "no list when no entries");
+
+        MMDB_entry_data_list_s *const entry = data_pool_get(pool);
+        ok(entry != NULL, "got an entry");
+
+        MMDB_entry_data_list_s *const list_one_element =
+            data_pool_to_list(pool);
+        ok(list_one_element != NULL, "got a list");
+        ok(list_one_element == entry,
+           "list's first element is the first we retrieved");
+        ok(list_one_element->next == NULL, "list ends with this element");
+
+        data_pool_destroy(pool);
+    }
+
+    {
+        size_t const initial_size = 2;
+        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
+        ok(pool != NULL, "created pool");
+
+        MMDB_entry_data_list_s *const list_empty = data_pool_to_list(pool);
+        ok(list_empty == NULL, "no list when no entries");
+
+        MMDB_entry_data_list_s *const entry1 = data_pool_get(pool);
+        ok(entry1 != NULL, "got an entry");
+        MMDB_entry_data_list_s *const entry2 = data_pool_get(pool);
+        ok(entry2 != NULL, "got an entry");
+        ok(entry1 != entry2, "second entry is different from the first");
+
+        MMDB_entry_data_list_s *const list_element1 =
+            data_pool_to_list(pool);
+        ok(list_element1 != NULL, "got a list");
+        ok(list_element1 == entry1,
+           "list's first element is the first we retrieved");
+
+        MMDB_entry_data_list_s *const list_element2 = list_element1->next;
+        ok(list_element2 == entry2,
+           "second element is the second we retrieved");
+        ok(list_element2->next == NULL, "list ends with this element");
+
+        data_pool_destroy(pool);
+    }
 }


### PR DESCRIPTION
Before this we were actually accessing the last+1 and setting that to
NULL. The list would often be valid if our last element happened to be
in a part of memory that we zeroed. This changes to correctly set the
last element in the list.