### PR TITLE
remove build problems related to rpl_malloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,6 @@ AC_C_BIGENDIAN(
         [AC_DEFINE([MMDB_LITTLE_ENDIAN], [0], [System is big-endian])],
         [AC_DEFINE([MMDB_LITTLE_ENDIAN], [1], [System is little-endian])])
 
-AC_FUNC_MALLOC
 AC_FUNC_MMAP
 
 AC_SEARCH_LIBS([fabs], [m])


### PR DESCRIPTION
The rpl_malloc() entry is created by AC_FUNC_MALLOC configure check
if it does not like the default malloc implementation. The idea is
to support malloc(0). However, that is considered dangerous in any
case from a security point of view and should be avoided inside code.
So security-aware code does not need it.

On the other hand, AC_FUNC_MALLOC is known for false positives, often
resulting in the creation of calls to rpl_malloc(), which the
user would need to provide. This happens depending on compiler and
OS/distro being used.

Note that the usefulness of that macro is even questioned on the
autoconf mailing list:
https://lists.gnu.org/archive/html/autoconf/2003-02/msg00017.html

So the solution is to simply remove that macro.

Note: we have done this in the rsyslog project more than 2 years
ago and made only positive experience.

closes https://github.com/maxmind/libmaxminddb/issues/144