### PR TITLE
Allocate in multiple chunks rather than reallocating one single chunk

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+* Allocate memory for `MMDB_entry_data_list_s` structs in separate chunks
+  rather than one large chunk. This simplifies accessing memory in
+  `MMDB_get_entry_data_list()` and increases performance. It builds on the
+  changes in 1.3.0 and 1.3.1.
+
+
 ## 1.3.1 - 2017-11-24
 
 * Fix build problems related to `rpl_malloc()`. Pull request by Rainer

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -5,5 +5,6 @@ AM_LDFLAGS = $(top_builddir)/src/libmaxminddb.la
 bin_PROGRAMS = mmdblookup
 
 if !WINDOWS
-mmdblookup_CFLAGS = $(CFLAGS) -pthread
+AM_CPPFLAGS += -pthread
+AM_LDFLAGS += -pthread
 endif

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -135,6 +135,7 @@ typedef struct MMDB_entry_data_s {
 typedef struct MMDB_entry_data_list_s {
     MMDB_entry_data_s entry_data;
     struct MMDB_entry_data_list_s *next;
+    bool head;
 } MMDB_entry_data_list_s;
 
 typedef struct MMDB_description_s {

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -135,7 +135,7 @@ typedef struct MMDB_entry_data_s {
 typedef struct MMDB_entry_data_list_s {
     MMDB_entry_data_s entry_data;
     struct MMDB_entry_data_list_s *next;
-    bool head;
+    void *pool;
 } MMDB_entry_data_list_s;
 
 typedef struct MMDB_description_s {

--- a/src/data-pool.h
+++ b/src/data-pool.h
@@ -44,10 +44,9 @@ typedef struct MMDB_data_pool_s {
     MMDB_entry_data_list_s *blocks[DATA_POOL_NUM_BLOCKS];
 } MMDB_data_pool_s;
 
-int data_pool_new(size_t const, MMDB_data_pool_s *const);
-void data_pool_destroy(MMDB_data_pool_s *const, bool const);
+MMDB_data_pool_s *data_pool_new(size_t const);
+void data_pool_destroy(MMDB_data_pool_s *const);
 MMDB_entry_data_list_s *data_pool_alloc(MMDB_data_pool_s *const);
-bool data_pool_list_destroy(MMDB_entry_data_list_s *const);
 MMDB_entry_data_list_s *data_pool_to_list(MMDB_data_pool_s *const);
 
 #endif

--- a/src/data-pool.h
+++ b/src/data-pool.h
@@ -33,14 +33,21 @@ typedef struct MMDB_data_pool_s {
     // How many used in the current block, counting by structs.
     size_t used;
 
+    // The current block we're allocating out of.
+    MMDB_entry_data_list_s *block;
+
+    // The size of each block.
+    size_t sizes[DATA_POOL_NUM_BLOCKS];
+
     // An array of pointers to blocks of memory holding space for list
     // elements.
     MMDB_entry_data_list_s *blocks[DATA_POOL_NUM_BLOCKS];
 } MMDB_data_pool_s;
 
-MMDB_data_pool_s *data_pool_new(size_t const);
+int data_pool_new(size_t const, MMDB_data_pool_s *const);
 void data_pool_destroy(MMDB_data_pool_s *const, bool const);
 MMDB_entry_data_list_s *data_pool_alloc(MMDB_data_pool_s *const);
 bool data_pool_list_destroy(MMDB_entry_data_list_s *const);
+MMDB_entry_data_list_s *data_pool_to_list(MMDB_data_pool_s *const);
 
 #endif

--- a/src/data-pool.h
+++ b/src/data-pool.h
@@ -2,46 +2,45 @@
 #define DATA_POOL_H
 
 #include "maxminddb.h"
+
+#include <stdbool.h>
 #include <stddef.h>
 
+// This should be large enough that we never need to grow the array of pointers
+// to blocks. 32 is enough. Even starting out of with size 1 (1 struct), the
+// 32nd element alone will provide 2**32 structs as we exponentially increase
+// the number in each block. Being confident that we do not have to grow the
+// array lets us avoid writing code to do that. That code would be risky as it
+// would rarely be hit and likely not be well tested.
+#define DATA_POOL_NUM_BLOCKS 32
+
 // A pool of memory for MMDB_entry_data_list_s structs. This is so we can
-// allocate multiple up front rather than one at a time. It gives performance
-// benefits.
+// allocate multiple up front rather than one at a time for performance
+// reasons.
 //
-// You can think of the pool as an array. The order you add elements to it (by
-// calling data_pool_get()) ends up as the order of the list you create with
-// data_pool_to_list().
+// The order you add elements to it (by calling data_pool_alloc()) ends up as
+// the order of the list.
 //
 // The memory only grows. There is no support for releasing an element you take
 // back to the pool.
 typedef struct MMDB_data_pool_s {
-    // The pool of memory for structs. The location of the memory is not stable
-    // as we use realloc() to grow it. As such, the next pointers are not
-    // useful until you call data_pool_to_list().
-    MMDB_entry_data_list_s *data;
+    // Index of the current block we're allocating out of.
+    size_t index;
 
-    // The size of the pool, counting by structs.
+    // The size of the current block, counting by structs.
     size_t size;
 
-    // The number of structs in use in the pool.
-    size_t used_size;
+    // How many used in the current block, counting by structs.
+    size_t used;
 
-    // The maximum amount of memory we'll allocate. This defaults to SIZE_MAX.
-    // It exists so we can test hitting this.
-    size_t max_bytes;
-
-    // Keep track of how many times we allocate memory for the pool. This is an
-    // aid for introspection.
-    unsigned int num_allocs;
+    // An array of pointers to blocks of memory holding space for list
+    // elements.
+    MMDB_entry_data_list_s *blocks[DATA_POOL_NUM_BLOCKS];
 } MMDB_data_pool_s;
 
 MMDB_data_pool_s *data_pool_new(size_t const);
-void data_pool_destroy(MMDB_data_pool_s *const);
-int data_pool_alloc(MMDB_data_pool_s *const, size_t *const);
-MMDB_entry_data_list_s *data_pool_lookup(
-    MMDB_data_pool_s const *const,
-    size_t const
-    );
-MMDB_entry_data_list_s *data_pool_to_list(MMDB_data_pool_s *const);
+void data_pool_destroy(MMDB_data_pool_s *const, bool const);
+MMDB_entry_data_list_s *data_pool_alloc(MMDB_data_pool_s *const);
+bool data_pool_list_destroy(MMDB_entry_data_list_s *const);
 
 #endif

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1648,7 +1648,17 @@ int MMDB_get_metadata_as_entry_data_list(
 int MMDB_get_entry_data_list(
     MMDB_entry_s *start, MMDB_entry_data_list_s **const entry_data_list)
 {
-    MMDB_data_pool_s pool = { 0 };
+    // We should be able to just use = {0}. However, there appears to be a bug
+    // in Clang where we get false positives about missing initializers:
+    // https://bugs.llvm.org/show_bug.cgi?id=21689
+    MMDB_data_pool_s pool = {
+        .index  = 0,
+        .size   = 0,
+        .used   = 0,
+        .block  = NULL,
+        .sizes  = { 0 },
+        .blocks = { 0 },
+    };
     if (data_pool_new(MMDB_POOL_INIT_SIZE, &pool) != 0) {
         return MMDB_OUT_OF_MEMORY_ERROR;
     }

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -182,7 +182,7 @@ LOCAL uint32_t get_ptr_from(uint8_t ctrl, uint8_t const *const ptr,
                             int ptr_size);
 LOCAL int get_entry_data_list(MMDB_s *mmdb,
                               uint32_t offset,
-                              size_t const index,
+                              MMDB_entry_data_list_s *const entry_data_list,
                               MMDB_data_pool_s *const pool,
                               int depth);
 LOCAL float get_ieee754_float(const uint8_t *restrict p);
@@ -1653,32 +1653,26 @@ int MMDB_get_entry_data_list(
         return MMDB_OUT_OF_MEMORY_ERROR;
     }
 
-    size_t index = 0;
-    if (data_pool_alloc(pool, &index) != 0) {
-        data_pool_destroy(pool);
+    MMDB_entry_data_list_s *const list = data_pool_alloc(pool);
+    if (!list) {
+        data_pool_destroy(pool, false);
         return MMDB_OUT_OF_MEMORY_ERROR;
     }
 
-    int const status = get_entry_data_list(start->mmdb, start->offset, index,
+    int const status = get_entry_data_list(start->mmdb, start->offset, list,
                                            pool, 0);
 
-    *entry_data_list = data_pool_to_list(pool);
-    if (!*entry_data_list) {
-        data_pool_destroy(pool);
-        // This error code is not particularly accurate. However this really
-        // shouldn't happen.
-        return MMDB_OUT_OF_MEMORY_ERROR;
-    }
+    *entry_data_list = list;
 
     // The caller doesn't know about the pool. Just the list.
-    free(pool);
+    data_pool_destroy(pool, true);
 
     return status;
 }
 
 LOCAL int get_entry_data_list(MMDB_s *mmdb,
                               uint32_t offset,
-                              size_t const index,
+                              MMDB_entry_data_list_s *const entry_data_list,
                               MMDB_data_pool_s *const pool,
                               int depth)
 {
@@ -1687,17 +1681,6 @@ LOCAL int get_entry_data_list(MMDB_s *mmdb,
         return MMDB_INVALID_DATA_ERROR;
     }
     depth++;
-
-    // Note it is important to never re-use memory pointing into the pool after
-    // it may have changed in size. This is because the memory location may
-    // move when it grows. In practice this means that if we ever call
-    // data_pool_alloc() or this function recursively, all MMDB_entry_data_list
-    // pointers should be considered invalid, and you should look them up again
-    // by their index.
-    MMDB_entry_data_list_s *entry_data_list = data_pool_lookup(pool, index);
-    if (!entry_data_list) {
-        return MMDB_INVALID_DATA_ERROR;
-    }
     CHECKED_DECODE_ONE(mmdb, offset, &entry_data_list->entry_data);
 
     switch (entry_data_list->entry_data.type) {
@@ -1718,17 +1701,13 @@ LOCAL int get_entry_data_list(MMDB_s *mmdb,
             if (entry_data_list->entry_data.type == MMDB_DATA_TYPE_ARRAY
                 || entry_data_list->entry_data.type == MMDB_DATA_TYPE_MAP) {
 
-                int status = get_entry_data_list(mmdb, last_offset, index, pool,
-                                                 depth);
+                int status =
+                    get_entry_data_list(mmdb, last_offset, entry_data_list,
+                                        pool, depth);
                 if (MMDB_SUCCESS != status) {
                     DEBUG_MSG("get_entry_data_list on pointer failed.");
                     return status;
                 }
-            }
-
-            entry_data_list = data_pool_lookup(pool, index);
-            if (!entry_data_list) {
-                return MMDB_INVALID_DATA_ERROR;
             }
             entry_data_list->entry_data.offset_to_next = next_offset;
         }
@@ -1738,31 +1717,24 @@ LOCAL int get_entry_data_list(MMDB_s *mmdb,
             uint32_t array_size = entry_data_list->entry_data.data_size;
             uint32_t array_offset = entry_data_list->entry_data.offset_to_next;
             while (array_size-- > 0) {
-                size_t index2 = 0;
-                if (data_pool_alloc(pool, &index2) != 0) {
+                MMDB_entry_data_list_s *entry_data_list_to =
+                    data_pool_alloc(pool);
+                if (!entry_data_list_to) {
                     return MMDB_OUT_OF_MEMORY_ERROR;
                 }
 
-                int status = get_entry_data_list(mmdb, array_offset, index2,
-                                                 pool, depth);
+                int status =
+                    get_entry_data_list(mmdb, array_offset, entry_data_list_to,
+                                        pool, depth);
                 if (MMDB_SUCCESS != status) {
                     DEBUG_MSG("get_entry_data_list on array element failed.");
                     return status;
                 }
 
-                MMDB_entry_data_list_s *entry_data_list_to
-                    = data_pool_lookup(pool, index2);
-                if (!entry_data_list_to) {
-                    return MMDB_INVALID_DATA_ERROR;
-                }
                 array_offset = entry_data_list_to->entry_data.offset_to_next;
             }
-
-            entry_data_list = data_pool_lookup(pool, index);
-            if (!entry_data_list) {
-                return MMDB_INVALID_DATA_ERROR;
-            }
             entry_data_list->entry_data.offset_to_next = array_offset;
+
         }
         break;
     case MMDB_DATA_TYPE_MAP:
@@ -1771,47 +1743,32 @@ LOCAL int get_entry_data_list(MMDB_s *mmdb,
 
             offset = entry_data_list->entry_data.offset_to_next;
             while (size-- > 0) {
-                size_t key_index = 0;
-                if (data_pool_alloc(pool, &key_index) != 0) {
+                MMDB_entry_data_list_s *list_key = data_pool_alloc(pool);
+                if (!list_key) {
                     return MMDB_OUT_OF_MEMORY_ERROR;
                 }
 
-                int status = get_entry_data_list(mmdb, offset, key_index, pool,
-                                                 depth);
+                int status =
+                    get_entry_data_list(mmdb, offset, list_key, pool, depth);
                 if (MMDB_SUCCESS != status) {
                     DEBUG_MSG("get_entry_data_list on map key failed.");
                     return status;
                 }
 
-                MMDB_entry_data_list_s *entry_data_list_to
-                    = data_pool_lookup(pool, key_index);
-                if (!entry_data_list_to) {
-                    return MMDB_INVALID_DATA_ERROR;
-                }
-                offset = entry_data_list_to->entry_data.offset_to_next;
+                offset = list_key->entry_data.offset_to_next;
 
-                size_t value_index = 0;
-                if (data_pool_alloc(pool, &value_index) != 0) {
+                MMDB_entry_data_list_s *list_value = data_pool_alloc(pool);
+                if (!list_value) {
                     return MMDB_OUT_OF_MEMORY_ERROR;
                 }
 
-                status = get_entry_data_list(mmdb, offset, value_index, pool,
+                status = get_entry_data_list(mmdb, offset, list_value, pool,
                                              depth);
                 if (MMDB_SUCCESS != status) {
                     DEBUG_MSG("get_entry_data_list on map element failed.");
                     return status;
                 }
-
-                entry_data_list_to = data_pool_lookup(pool, value_index);
-                if (!entry_data_list_to) {
-                    return MMDB_INVALID_DATA_ERROR;
-                }
-                offset = entry_data_list_to->entry_data.offset_to_next;
-            }
-
-            entry_data_list = data_pool_lookup(pool, index);
-            if (!entry_data_list) {
-                return MMDB_INVALID_DATA_ERROR;
+                offset = list_value->entry_data.offset_to_next;
             }
             entry_data_list->entry_data.offset_to_next = offset;
         }
@@ -1895,7 +1852,7 @@ void MMDB_free_entry_data_list(MMDB_entry_data_list_s *const entry_data_list)
     if (entry_data_list == NULL) {
         return;
     }
-    free(entry_data_list);
+    data_pool_list_destroy(entry_data_list);
 }
 
 void MMDB_close(MMDB_s *const mmdb)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -17,6 +17,8 @@ check_PROGRAMS = \
 	no_map_get_value_t read_node_t threads_t version_t
 
 data_pool_t_CFLAGS = $(CFLAGS) -I$(top_srcdir)/src
+data_pool_t_LDFLAGS = $(AM_LDFLAGS) -lm
+
 threads_t_CFLAGS = $(CFLAGS) -pthread
 
 TESTS = $(check_PROGRAMS) compile_c++_t.pl mmdblookup_t.pl

--- a/t/data-pool-t.c
+++ b/t/data-pool-t.c
@@ -9,8 +9,6 @@ static void test_data_pool_new(void);
 static void test_data_pool_destroy(void);
 static void test_data_pool_alloc(void);
 static void test_data_pool_to_list(void);
-static bool create_and_destroy_pool(size_t const,
-                                    size_t const);
 static bool create_and_check_list(size_t const,
                                   size_t const);
 static void check_block_count(MMDB_entry_data_list_s const *const,
@@ -290,30 +288,9 @@ static void test_data_pool_to_list(void)
 
         for (size_t element_count = 0; element_count < max_element_count;
              element_count++) {
-            assert(create_and_destroy_pool(initial_size, element_count));
             assert(create_and_check_list(initial_size, element_count));
         }
     }
-}
-
-// Use assert() rather than libtap as libtap is significantly slower and we run
-// this frequently.
-//
-// This is to test us passing false to data_pool_destroy() with varying sizes.
-static bool create_and_destroy_pool(size_t const initial_size,
-                                    size_t const element_count)
-{
-    MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-    assert(pool != NULL);
-
-    for (size_t i = 0; i < element_count; i++) {
-        MMDB_entry_data_list_s *const entry = data_pool_alloc(pool);
-        assert(entry != NULL);
-    }
-
-    data_pool_destroy(pool);
-
-    return true;
 }
 
 // Use assert() rather than libtap as libtap is significantly slower and we run

--- a/t/data-pool-t.c
+++ b/t/data-pool-t.c
@@ -29,21 +29,22 @@ int main(void)
 static void test_data_pool_new(void)
 {
     {
-        MMDB_data_pool_s *const pool = data_pool_new(0);
-        ok(pool == NULL, "size 0 is not valid");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(0, &pool) - 1, "size 0 is not valid");
     }
 
     {
-        MMDB_data_pool_s *const pool = data_pool_new(SIZE_MAX - 10);
-        ok(pool == NULL, "very large size is not valid");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(SIZE_MAX - 10, &pool) == -1,
+           "very large size is not valid");
     }
 
     {
-        MMDB_data_pool_s *const pool = data_pool_new(512);
-        ok(pool != NULL, "size 512 is valid");
-        cmp_ok(pool->size, "==", 512, "size is 512");
-        cmp_ok(pool->used, "==", 0, "used size is 0");
-        data_pool_destroy(pool, false);
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(512, &pool) == 0, "size 512 is valid");
+        cmp_ok(pool.size, "==", 512, "size is 512");
+        cmp_ok(pool.used, "==", 0, "used size is 0");
+        data_pool_destroy(&pool, false);
     }
 }
 
@@ -54,47 +55,48 @@ static void test_data_pool_destroy(void)
     }
 
     {
-        MMDB_data_pool_s *const pool = data_pool_new(512);
-        data_pool_destroy(pool, false);
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(512, &pool) == 0, "created pool");
+        data_pool_destroy(&pool, false);
     }
 }
 
 static void test_data_pool_alloc(void)
 {
     {
-        MMDB_data_pool_s *const pool = data_pool_new(1);
-        ok(pool != NULL, "created pool");
-        cmp_ok(pool->used, "==", 0, "used size starts at 0");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(1, &pool) == 0, "created pool");
+        cmp_ok(pool.used, "==", 0, "used size starts at 0");
 
-        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(&pool);
         ok(entry1 != NULL, "allocated first entry");
         // Arbitrary so that we can recognize it.
         entry1->entry_data.offset = (uint32_t)123;
 
-        cmp_ok(pool->size, "==", 1, "size is still 1");
-        cmp_ok(pool->used, "==", 1, "used size is 1 after taking one");
+        cmp_ok(pool.size, "==", 1, "size is still 1");
+        cmp_ok(pool.used, "==", 1, "used size is 1 after taking one");
 
-        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(&pool);
         ok(entry2 != NULL, "got another entry");
         ok(entry1 != entry2, "second entry is different from first entry");
 
-        cmp_ok(pool->size, "==", 2, "size is 2 (new block)");
-        cmp_ok(pool->used, "==", 1, "used size is 1 in current block");
+        cmp_ok(pool.size, "==", 2, "size is 2 (new block)");
+        cmp_ok(pool.used, "==", 1, "used size is 1 in current block");
 
         ok(entry1->entry_data.offset == 123,
            "accessing the original entry's memory is ok");
 
-        data_pool_destroy(pool, false);
+        data_pool_destroy(&pool, false);
     }
 
     {
         size_t const initial_size = 10;
-        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-        ok(pool != NULL, "created pool");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(initial_size, &pool) == 0, "created pool");
 
         MMDB_entry_data_list_s *entry1 = NULL;
         for (size_t i = 0; i < initial_size; i++) {
-            MMDB_entry_data_list_s *const entry = data_pool_alloc(pool);
+            MMDB_entry_data_list_s *const entry = data_pool_alloc(&pool);
             ok(entry != NULL, "got an entry");
             // Give each a unique number so we can check it.
             entry->entry_data.offset = (uint32_t)i;
@@ -103,18 +105,18 @@ static void test_data_pool_alloc(void)
             }
         }
 
-        cmp_ok(pool->size, "==", initial_size, "size is the initial size");
-        cmp_ok(pool->used, "==", initial_size, "used size is as expected");
+        cmp_ok(pool.size, "==", initial_size, "size is the initial size");
+        cmp_ok(pool.used, "==", initial_size, "used size is as expected");
 
-        MMDB_entry_data_list_s *const entry = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry = data_pool_alloc(&pool);
         ok(entry != NULL, "got an entry");
         entry->entry_data.offset = (uint32_t)initial_size;
 
-        cmp_ok(pool->size, "==", initial_size * 2,
+        cmp_ok(pool.size, "==", initial_size * 2,
                "size is the initial size*2");
-        cmp_ok(pool->used, "==", 1, "used size is as expected");
+        cmp_ok(pool.used, "==", 1, "used size is as expected");
 
-        MMDB_entry_data_list_s *const list = entry1;
+        MMDB_entry_data_list_s *const list = data_pool_to_list(&pool);
 
         MMDB_entry_data_list_s *element = list;
         for (size_t i = 0; i < initial_size + 1; i++) {
@@ -130,7 +132,7 @@ static void test_data_pool_alloc(void)
         ok(entry1->entry_data.offset == (uint32_t)0,
            "accessing entry1's original memory is ok after growing the pool");
 
-        data_pool_destroy(pool, true);
+        data_pool_destroy(&pool, true);
 
         element = list;
         for (size_t i = 0; i < initial_size + 1; i++) {
@@ -152,22 +154,24 @@ static void test_data_pool_to_list(void)
 {
     {
         size_t const initial_size = 16;
-        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-        ok(pool != NULL, "created pool");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(initial_size, &pool) == 0, "created pool");
 
-        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(&pool);
         ok(entry1 != NULL, "got an entry");
 
-        MMDB_entry_data_list_s *const list_one_element = entry1;
+        MMDB_entry_data_list_s *const list_one_element
+            = data_pool_to_list(&pool);
         ok(list_one_element != NULL, "got a list");
         ok(list_one_element == entry1,
            "list's first element is the first we retrieved");
         ok(list_one_element->next == NULL, "list is one element in size");
 
-        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(&pool);
         ok(entry2 != NULL, "got another entry");
 
-        MMDB_entry_data_list_s *const list_two_elements = entry1;
+        MMDB_entry_data_list_s *const list_two_elements
+            = data_pool_to_list(&pool);
         ok(list_two_elements != NULL, "got a list");
         ok(list_two_elements == entry1,
            "list's first element is the first we retrieved");
@@ -178,39 +182,40 @@ static void test_data_pool_to_list(void)
            "second item in list is second we retrieved");
         ok(second_element->next == NULL, "list ends with the second element");
 
-        data_pool_destroy(pool, false);
+        data_pool_destroy(&pool, false);
     }
 
     {
         size_t const initial_size = 1;
-        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-        ok(pool != NULL, "created pool");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(initial_size, &pool) == 0, "created pool");
 
-        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(&pool);
         ok(entry1 != NULL, "got an entry");
 
-        MMDB_entry_data_list_s *const list_one_element = entry1;
+        MMDB_entry_data_list_s *const list_one_element
+            = data_pool_to_list(&pool);
         ok(list_one_element != NULL, "got a list");
         ok(list_one_element == entry1,
            "list's first element is the first we retrieved");
         ok(list_one_element->next == NULL, "list ends with this element");
 
-        data_pool_destroy(pool, false);
+        data_pool_destroy(&pool, false);
     }
 
     {
         size_t const initial_size = 2;
-        MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-        ok(pool != NULL, "created pool");
+        MMDB_data_pool_s pool = { 0 };
+        ok(data_pool_new(initial_size, &pool) == 0, "created pool");
 
-        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry1 = data_pool_alloc(&pool);
         ok(entry1 != NULL, "got an entry");
 
-        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry2 = data_pool_alloc(&pool);
         ok(entry2 != NULL, "got an entry");
         ok(entry1 != entry2, "second entry is different from the first");
 
-        MMDB_entry_data_list_s *const list_element1 = entry1;
+        MMDB_entry_data_list_s *const list_element1 = data_pool_to_list(&pool);
         ok(list_element1 != NULL, "got a list");
         ok(list_element1 == entry1,
            "list's first element is the first we retrieved");
@@ -220,7 +225,7 @@ static void test_data_pool_to_list(void)
            "second element is the second we retrieved");
         ok(list_element2->next == NULL, "list ends with this element");
 
-        data_pool_destroy(pool, false);
+        data_pool_destroy(&pool, false);
     }
 
     {
@@ -313,15 +318,15 @@ static void test_data_pool_to_list(void)
 static bool create_and_destroy_pool(size_t const initial_size,
                                     size_t const element_count)
 {
-    MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-    assert(pool != NULL);
+    MMDB_data_pool_s pool = { 0 };
+    assert(data_pool_new(initial_size, &pool) == 0);
 
     for (size_t i = 0; i < element_count; i++) {
-        MMDB_entry_data_list_s *const entry = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry = data_pool_alloc(&pool);
         assert(entry != NULL);
     }
 
-    data_pool_destroy(pool, false);
+    data_pool_destroy(&pool, false);
 
     return true;
 }
@@ -331,10 +336,10 @@ static bool create_and_destroy_pool(size_t const initial_size,
 static bool create_and_check_list(size_t const initial_size,
                                   size_t const element_count)
 {
-    MMDB_data_pool_s *const pool = data_pool_new(initial_size);
-    assert(pool != NULL);
+    MMDB_data_pool_s pool = { 0 };
+    assert(data_pool_new(initial_size, &pool) == 0);
 
-    assert(pool->used == 0);
+    assert(pool.used == 0);
 
     // Hold on to the pointers as we initially see them so that we can check
     // they are still valid after building the list.
@@ -342,32 +347,27 @@ static bool create_and_check_list(size_t const initial_size,
         = calloc(element_count, sizeof(MMDB_entry_data_list_s *));
     assert(entry_array != NULL);
 
-    MMDB_entry_data_list_s *entry1 = NULL;
     for (size_t i = 0; i < element_count; i++) {
-        MMDB_entry_data_list_s *const entry = data_pool_alloc(pool);
+        MMDB_entry_data_list_s *const entry = data_pool_alloc(&pool);
         assert(entry != NULL);
-
-        if (i == 0) {
-            entry1 = entry;
-        }
 
         entry->entry_data.offset = (uint32_t)i;
 
         entry_array[i] = entry;
     }
 
-    MMDB_entry_data_list_s *const list = entry1;
+    MMDB_entry_data_list_s *const list = data_pool_to_list(&pool);
 
     if (element_count == 0) {
         assert(list == NULL);
-        data_pool_destroy(pool, false);
+        data_pool_destroy(&pool, false);
         free(entry_array);
         return true;
     }
 
     assert(list != NULL);
 
-    data_pool_destroy(pool, true);
+    data_pool_destroy(&pool, true);
 
     MMDB_entry_data_list_s *element = list;
     for (size_t i = 0; i < element_count; i++) {


### PR DESCRIPTION
This allows the pointers to list elements to be valid even when the
pool's size grows.