### PR TITLE
Use O_CLOEXEC for fork-safety in MMDB_open

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -375,7 +375,7 @@ LOCAL int map_file(MMDB_s *const mmdb)
     ssize_t size;
     int status = MMDB_SUCCESS;
 
-    int fd = open(mmdb->filename, O_RDONLY);
+    int fd = open(mmdb->filename, O_RDONLY | O_CLOEXEC);
     struct stat s;
     if (fd < 0 || fstat(fd, &s)) {
         status = MMDB_FILE_OPEN_ERROR;


### PR DESCRIPTION
Otherwise, a program which might concurrently call MMDB_open() and
fork() in different threads of execution cannot prevent the
possible leak of a copy of the temporary database filehandle to
the new child process.