### PR TITLE
Add -export-symbols-regexp to LDFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libmaxminddb.la
 
 libmaxminddb_la_SOURCES = maxminddb.c maxminddb-compat-util.h \
 	data-pool.c data-pool.h
-libmaxminddb_la_LDFLAGS = -version-info 0:7:0
+libmaxminddb_la_LDFLAGS = -version-info 0:7:0 -export-symbols-regex '^MMDB_.*'
 include_HEADERS = $(top_srcdir)/include/maxminddb.h
 
 pkgconfig_DATA = libmaxminddb.pc

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -18,6 +18,7 @@ check_PROGRAMS = \
 
 data_pool_t_CFLAGS = $(CFLAGS) -I$(top_srcdir)/src
 data_pool_t_LDFLAGS = $(AM_LDFLAGS) -lm
+data_pool_t_SOURCES = data-pool-t.c ../src/data-pool.c
 
 threads_t_CFLAGS = $(CFLAGS) -pthread
 


### PR DESCRIPTION
As to only export symbols starting with "MMDB_" and in lieu of a proper
version script. This helps by filtering out the new data_pool_* symbols,
which are internal-only and should not exposed to applications using
libmaxminddb.

The change to LDFLAGS would introduce a test failure, as data-pool-t
used those internal functions, but this is addressed by adding
src/data-pool.c to data-pool-t's SOURCES, as suggested by Will Storey.

This resolves #160.