### PR TITLE
Add --disable-binaries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,12 @@ include_HEADERS = include/maxminddb.h
 nodist_include_HEADERS = include/maxminddb_config.h
 
 SUBDIRS = \
-  src     \
+  src
+
+if BINARIES
+SUBDIRS += \
   bin
+endif
 
 if TESTS
 SUBDIRS += \

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,12 @@ AC_ARG_ENABLE(
         esac],[debug=false])
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 
+AC_ARG_ENABLE([binaries],
+        AS_HELP_STRING([--enable-binaries], [Compilation of binaries code]),
+        [enable_binaries=${enableval}],
+        [enable_binaries=yes])
+AM_CONDITIONAL([BINARIES], [test "${enable_binaries}" = "yes"])
+
 AC_ARG_ENABLE([tests],
         AS_HELP_STRING([--enable-tests], [Compilation of tests code]),
         [enable_tests=${enableval}],


### PR DESCRIPTION
mmdblookup now depends on pthread.h which can be disabled on some
toolchains so add an option to be able to compile libmaxminddb without
this binary

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>