### PR TITLE
Use UTF-8 internally on Windows.

### DIFF
--- a/doc/libmaxminddb.md
+++ b/doc/libmaxminddb.md
@@ -427,6 +427,8 @@ if (MMDB_SUCCESS != status) { ... }
 MMDB_close(&mmdb);
 ```
 
+`filename` must be encoded as UTF-8 on Windows.
+
 The `MMDB_s` structure you pass in can be on the stack or allocated from the
 heap. However, if the open is successful it will contain heap-allocated data,
 so you need to close it with `MMDB_close()`. If the status returned is not

--- a/projects/VS12/maxminddb_config.h
+++ b/projects/VS12/maxminddb_config.h
@@ -11,4 +11,8 @@
 #define MMDB_UINT128_IS_BYTE_ARRAY 1
 #endif
 
+#ifndef UNICODE
+#define UNICODE
+#endif
+
 #endif                          /* MAXMINDDB_CONFIG_H */


### PR DESCRIPTION
Define UNICODE on Windows so that we use the wide Win32 API.

Note that MMDB_open takes a UTF-8 encoded filename on Windows.

In maxminddb.c, convert our filename from UTF-8 to UTF-16 before calling
CreateFile.

In mmdblookup.c, use `wmain` as our main entry point on Windows. Convert
our argument list from UTF-16 to UTF-8.

Add some casts in order to appease Visual C++.