### PR TITLE
Don't force the Unicode API on Windows consumers.

### DIFF
--- a/bin/mmdblookup.c
+++ b/bin/mmdblookup.c
@@ -14,6 +14,9 @@
 #include <time.h>
 
 #ifdef _WIN32
+#ifndef UNICODE
+#define UNICODE
+#endif
 #include <malloc.h>
 #else
 #include <libgen.h>

--- a/projects/VS12/maxminddb_config.h
+++ b/projects/VS12/maxminddb_config.h
@@ -11,8 +11,4 @@
 #define MMDB_UINT128_IS_BYTE_ARRAY 1
 #endif
 
-#ifndef UNICODE
-#define UNICODE
-#endif
-
 #endif                          /* MAXMINDDB_CONFIG_H */

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -14,6 +14,9 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+#ifndef UNICODE
+#define UNICODE
+#endif
 #include <windows.h>
 #include <ws2ipdef.h>
 #else


### PR DESCRIPTION
We use Windows' Unicode API internally, but we shouldn't force that choice
on consumers. Make "#define UNICODE" internal in the modules that need it.