### PR TITLE
on Win32, cleanup handler in map_file can close uninitialized handle

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -340,12 +340,13 @@ LOCAL int map_file(MMDB_s *const mmdb)
     DWORD size;
     int status = MMDB_SUCCESS;
     HANDLE mmh = NULL;
+    HANDLE fd = INVALID_HANDLE_VALUE;
     LPWSTR utf16_filename = utf8_to_utf16(mmdb->filename);
     if (!utf16_filename) {
         status = MMDB_FILE_OPEN_ERROR;
         goto cleanup;
     }
-    HANDLE fd = CreateFile(utf16_filename, GENERIC_READ, FILE_SHARE_READ, NULL,
+    fd = CreateFile(utf16_filename, GENERIC_READ, FILE_SHARE_READ, NULL,
                            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (fd == INVALID_HANDLE_VALUE) {
         status = MMDB_FILE_OPEN_ERROR;


### PR DESCRIPTION
```
libmaxminddb/src/maxminddb.c:344:9: error: variable 'fd' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
    if (!utf16_filename) {
        ^~~~~~~~~~~~~~~
libmaxminddb/src/maxminddb.c:378:33: note: uninitialized use occurs here
    if (INVALID_HANDLE_VALUE != fd) {
                                ^~
libmaxminddb/src/maxminddb.c:344:5: note: remove the 'if' if its condition is always false
    if (!utf16_filename) {
    ^~~~~~~~~~~~~~~~~~~~~~
libmaxminddb/src/maxminddb.c:348:5: note: variable 'fd' is declared here
    HANDLE fd = CreateFile(utf16_filename, GENERIC_READ, FILE_SHARE_READ, NULL,
    ^
1 error generated.
```