### PR TITLE
Simplify search tree lookup

### DIFF
--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -174,6 +174,13 @@ typedef struct MMDB_ipv4_start_node_s {
     uint32_t node_value;
 } MMDB_ipv4_start_node_s;
 
+typedef struct MMDB_record_info_s {
+    uint16_t record_length;
+    uint32_t (*left_record_getter)(const uint8_t *);
+    uint32_t (*right_record_getter)(const uint8_t *);
+    uint8_t right_record_offset;
+} MMDB_record_info_s;
+
 typedef struct MMDB_s {
     uint32_t flags;
     const char *filename;
@@ -187,6 +194,7 @@ typedef struct MMDB_s {
     uint16_t depth;
     MMDB_ipv4_start_node_s ipv4_start_node;
     MMDB_metadata_s metadata;
+    MMDB_record_info_s record_info;
 } MMDB_s;
 
 typedef struct MMDB_search_node_s {

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -120,13 +120,6 @@ char *type_num_to_name(uint8_t num)
 #define MAYBE_CHECK_SIZE_OVERFLOW(...)
 #endif
 
-typedef struct record_info_s {
-    uint16_t record_length;
-    uint32_t (*left_record_getter)(const uint8_t *);
-    uint32_t (*right_record_getter)(const uint8_t *);
-    uint8_t right_record_offset;
-} record_info_s;
-
 #define METADATA_MARKER "\xab\xcd\xefMaxMind.com"
 /* This is 128kb */
 #define METADATA_BLOCK_MAX_SIZE 131072
@@ -156,7 +149,7 @@ LOCAL int find_address_in_search_tree(const MMDB_s *const mmdb,
                                       uint8_t *address,
                                       sa_family_t address_family,
                                       MMDB_lookup_result_s *result);
-LOCAL record_info_s record_info_for_database(const MMDB_s *const mmdb);
+LOCAL MMDB_record_info_s record_info_for_database(const MMDB_s *const mmdb);
 LOCAL int find_ipv4_start_node(MMDB_s *const mmdb);
 LOCAL uint8_t record_type(const MMDB_s *const mmdb, uint64_t record);
 LOCAL uint32_t get_left_28_bit_record(const uint8_t *record);
@@ -297,6 +290,8 @@ int MMDB_open(const char *const filename, uint32_t flags, MMDB_s *const mmdb)
     mmdb->metadata_section = metadata;
     mmdb->ipv4_start_node.node_value = 0;
     mmdb->ipv4_start_node.netmask = 0;
+
+    mmdb->record_info = record_info_for_database(mmdb);
 
     // We do this immediately as otherwise there is a race to set
     // ipv4_start_node.node_value and ipv4_start_node.netmask.
@@ -922,7 +917,7 @@ LOCAL int find_address_in_search_tree(const MMDB_s *const mmdb,
                                       sa_family_t address_family,
                                       MMDB_lookup_result_s *result)
 {
-    record_info_s record_info = record_info_for_database(mmdb);
+    MMDB_record_info_s record_info = mmdb->record_info;
     if (0 == record_info.right_record_offset) {
         return MMDB_UNKNOWN_DATABASE_FORMAT_ERROR;
     }
@@ -971,9 +966,9 @@ LOCAL int find_address_in_search_tree(const MMDB_s *const mmdb,
     return MMDB_SUCCESS;
 }
 
-LOCAL record_info_s record_info_for_database(const MMDB_s *const mmdb)
+LOCAL MMDB_record_info_s record_info_for_database(const MMDB_s *const mmdb)
 {
-    record_info_s record_info = {
+    MMDB_record_info_s record_info = {
         .record_length       = mmdb->full_record_byte_size,
         .right_record_offset = 0
     };
@@ -999,14 +994,14 @@ LOCAL record_info_s record_info_for_database(const MMDB_s *const mmdb)
 
 LOCAL int find_ipv4_start_node(MMDB_s *const mmdb)
 {
+    MMDB_record_info_s record_info = mmdb->record_info;
+
     /* In a pathological case of a database with a single node search tree,
      * this check will be true even after we've found the IPv4 start node, but
      * that doesn't seem worth trying to fix. */
     if (mmdb->ipv4_start_node.node_value != 0) {
         return MMDB_SUCCESS;
     }
-
-    record_info_s record_info = record_info_for_database(mmdb);
 
     const uint8_t *search_tree = mmdb->file_content;
     uint32_t node_value = 0;
@@ -1071,7 +1066,7 @@ LOCAL uint32_t get_right_28_bit_record(const uint8_t *record)
 int MMDB_read_node(const MMDB_s *const mmdb, uint32_t node_number,
                    MMDB_search_node_s *const node)
 {
-    record_info_s record_info = record_info_for_database(mmdb);
+    MMDB_record_info_s record_info = mmdb->record_info;
     if (0 == record_info.right_record_offset) {
         return MMDB_UNKNOWN_DATABASE_FORMAT_ERROR;
     }


### PR DESCRIPTION
Also reduce repeated calculations.

This moderately speeds up `find_address_in_search_tree`, but given that it isn't the bottleneck, it doesn't make much difference generally.