### PR TITLE
Display prefix length for record in mmdblookup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,8 @@
 * The internal use of the `MMDB_s` now has the `const` modifier. Public
   functions that accepted an `MMDB_s` as an argument now also declare it as
   `const`. Pull request by Kurt Johnson. GitHub #199.
+* `mmdblookup` now displays the prefix length for the record when using
+  the verbose flag. GitHub #172.
 
 ## 1.3.2 - 2018-01-17
 

--- a/bin/mmdblookup.c
+++ b/bin/mmdblookup.c
@@ -43,7 +43,8 @@ LOCAL bool lookup_from_file(MMDB_s *const mmdb,
                             bool const dump);
 LOCAL int lookup_and_print(MMDB_s *mmdb, const char *ip_address,
                            const char **lookup_path,
-                           int lookup_path_length);
+                           int lookup_path_length,
+                           bool verbose);
 LOCAL int benchmark(MMDB_s *mmdb, int iterations);
 LOCAL MMDB_lookup_result_s lookup_or_die(MMDB_s *mmdb, const char *ipstr);
 LOCAL void random_ipv4(char *ip);
@@ -131,7 +132,7 @@ int main(int argc, char **argv)
 
     if (0 == iterations) {
         exit(lookup_and_print(&mmdb, ip_address, lookup_path,
-                              lookup_path_length));
+                              lookup_path_length, verbose));
     }
 
     free((void *)lookup_path);
@@ -473,13 +474,22 @@ LOCAL bool lookup_from_file(MMDB_s *const mmdb,
 
 LOCAL int lookup_and_print(MMDB_s *mmdb, const char *ip_address,
                            const char **lookup_path,
-                           int lookup_path_length)
+                           int lookup_path_length,
+                           bool verbose)
 {
 
     MMDB_lookup_result_s result = lookup_or_die(mmdb, ip_address);
     MMDB_entry_data_list_s *entry_data_list = NULL;
 
     int exit_code = 0;
+
+    if (verbose) {
+        fprintf(
+            stdout,
+            "\n  Record prefix length: %d\n",
+            result.netmask
+            );
+    }
 
     if (result.found_entry) {
         int status;


### PR DESCRIPTION
When using verbose mode.

Closes #172.