### PR TITLE
Fix MinGW cross compilation

### DIFF
--- a/t/maxminddb_test_helper.h
+++ b/t/maxminddb_test_helper.h
@@ -14,7 +14,7 @@
 #include "libtap/tap.h"
 
 #ifdef _WIN32
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #define R_OK 4


### PR DESCRIPTION
Some file systems are case sensitive.

    In file included from maxminddb_test_helper.c:11:
    maxminddb_test_helper.h:16:10: fatal error: Winsock2.h: No such file or directory
    16 | #include <Winsock2.h>
        |          ^~~~~~~~~~~~