### PR TITLE
Revert ABI breaking change

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+## 1.4.2
+
+* The 1.4.0 release introduced a change that increased the size of `MMDB_s`,
+  unintentionally causing an ABI break. This release reverts the relevant
+  commit.
+
+
 ## 1.4.1 - 2019-11-01
 
 * The man page links for function calls were not generated correctly in

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -174,13 +174,6 @@ typedef struct MMDB_ipv4_start_node_s {
     uint32_t node_value;
 } MMDB_ipv4_start_node_s;
 
-typedef struct MMDB_record_info_s {
-    uint16_t record_length;
-    uint32_t (*left_record_getter)(const uint8_t *);
-    uint32_t (*right_record_getter)(const uint8_t *);
-    uint8_t right_record_offset;
-} MMDB_record_info_s;
-
 typedef struct MMDB_s {
     uint32_t flags;
     const char *filename;
@@ -194,7 +187,6 @@ typedef struct MMDB_s {
     uint16_t depth;
     MMDB_ipv4_start_node_s ipv4_start_node;
     MMDB_metadata_s metadata;
-    MMDB_record_info_s record_info;
 } MMDB_s;
 
 typedef struct MMDB_search_node_s {

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -151,6 +151,10 @@ typedef struct MMDB_description_s {
     const char *description;
 } MMDB_description_s;
 
+/* WARNING: do not add new fields to this struct without bumping the SONAME.
+ * The struct is allocated by the users of this library and increasing the
+ * size will cause existing users to allocate too little space when the shared
+ * library is upgraded */
 typedef struct MMDB_metadata_s {
     uint32_t node_count;
     uint16_t record_size;
@@ -167,13 +171,23 @@ typedef struct MMDB_metadata_s {
         size_t count;
         MMDB_description_s **descriptions;
     } description;
+    /* See above warning before adding fields */
 } MMDB_metadata_s;
 
+/* WARNING: do not add new fields to this struct without bumping the SONAME.
+ * The struct is allocated by the users of this library and increasing the
+ * size will cause existing users to allocate too little space when the shared
+ * library is upgraded */
 typedef struct MMDB_ipv4_start_node_s {
     uint16_t netmask;
     uint32_t node_value;
+    /* See above warning before adding fields */
 } MMDB_ipv4_start_node_s;
 
+/* WARNING: do not add new fields to this struct without bumping the SONAME.
+ * The struct is allocated by the users of this library and increasing the
+ * size will cause existing users to allocate too little space when the shared
+ * library is upgraded */
 typedef struct MMDB_s {
     uint32_t flags;
     const char *filename;
@@ -187,6 +201,7 @@ typedef struct MMDB_s {
     uint16_t depth;
     MMDB_ipv4_start_node_s ipv4_start_node;
     MMDB_metadata_s metadata;
+    /* See above warning before adding fields */
 } MMDB_s;
 
 typedef struct MMDB_search_node_s {


### PR DESCRIPTION
This commit introduced an unintended ABI change. Users of this library
allocate the space for `MMDB_s`. Any increase in size of `MMDB_s` may cause
us to write off the end of the struct unless the caller is recompiled.
