### PR TITLE
set RPATH when linking against libmaxminddb via pkgconfig

### DIFF
--- a/src/libmaxminddb.pc.in
+++ b/src/libmaxminddb.pc.in
@@ -7,5 +7,5 @@ Name: libmaxminddb
 Description: C library for the MaxMind DB file format
 URL: http://maxmind.github.io/libmaxminddb/
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lmaxminddb
+Libs: -L${libdir} -R${libdir} -lmaxminddb
 Cflags: -I${includedir}


### PR DESCRIPTION
When libmaxminddb is installed in a directory not included in the
default library search path, runtime linking may fail.

This patch adds the libdir to the RPATH when linking by the
configuration provided by pkgconfig.