### PR TITLE
A couple more manpage improvements

### DIFF
--- a/dev-bin/make-man-pages.pl
+++ b/dev-bin/make-man-pages.pl
@@ -16,16 +16,16 @@ sub main {
 
     my @translators = qw ( pandoc lowdown );
     my $translator;
-    foreach my $p ( @translators ) {
-        if (defined which($p)) {
+    foreach my $p (@translators) {
+        if ( defined which($p) ) {
             $translator = $p;
             last;
         }
     }
     unless ( defined $translator ) {
-        die
-        "\n  You must install one of " . join(', ', @translators) .
-        " in order to generate the man pages.\n\n";
+        die "\n  You must install one of "
+            . join( ', ', @translators )
+            . " in order to generate the man pages.\n\n";
     }
 
     _make_man( $translator, $target, 'libmaxminddb', 3 );
@@ -40,8 +40,10 @@ sub _make_man {
     my $name       = shift;
     my $section    = shift;
 
+    my $input   = "$Bin/../doc/$name.md";
     my $man_dir = "$target/man/man$section";
     mkpath($man_dir);
+    my $output = "$man_dir/$name.$section";
 
     my $tempdir = tempdir( CLEANUP => 1 );
 
@@ -55,13 +57,26 @@ EOF
     my $tempfile = "$tempdir/$name.$section.md";
     write_file( $tempfile, $markdown );
 
-    my $man_file = "$man_dir/$name.$section";
-
     if ( $translator eq 'pandoc' ) {
-        system( qw( pandoc -s -f markdown_mmd+backtick_code_blocks -t man ), $tempfile, '-o', $man_file );
-        _pandoc_postprocess($man_file);
-    } elsif ( $translator eq 'lowdown' ) {
-        system( qw( lowdown --out-no-smarty -s -Tman ), $tempfile, '-o', $man_file );
+        system(
+            'pandoc',
+            '-s',
+            '-f', 'markdown_mmd+backtick_code_blocks',
+            '-t', 'man',
+            $tempfile,
+            '-o', $output,
+        );
+        _pandoc_postprocess($output);
+    }
+    elsif ( $translator eq 'lowdown' ) {
+        system(
+            'lowdown',
+            '-s',
+            '--out-no-smarty',
+            '-Tman',
+            $tempfile,
+            '-o', $output,
+        );
     }
 }
 

--- a/dev-bin/make-man-pages.pl
+++ b/dev-bin/make-man-pages.pl
@@ -13,7 +13,7 @@ use File::Which qw( which );
 sub main {
     my $target = shift || "$Bin/..";
 
-    my @translators = qw ( pandoc lowdown );
+    my @translators = qw ( lowdown pandoc );
     my $translator;
     foreach my $p (@translators) {
         if ( defined which($p) ) {


### PR DESCRIPTION
Follow-up to #248. Sorry to do this peacemeal, but lowdown started supporting `-M` only with 0.8.1, released… today. (I wouldn't expect anyone generating manpages to not have a latest lowdown. I don't even know if there are others besides me ;)). On the plus side, the changelog entry for 1.5.1 is already there and doesn't need an update? :)

I hope to converge geoipupdate's and libmaxminddb's `dev-bin/make-man-pages.pl` eventually, but while one of the commits below is in that direction, I'm not there yet. If you have more copies of that in other MaxMind projects, happy to incorporate those as well and have one source for all.

Thanks for the consideration!