### PR TITLE
build: cmake: properly enable C99 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(maxminddb
   VERSION 1.5.2
 )
 set(MAXMINDDB_SOVERSION 0.0.7)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS OFF)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)
 option(BUILD_TESTING "Build test programs" ON)


### PR DESCRIPTION
libmaxminddb currently fails to build with gcc 4.9 and cmake because no `-std=` parameter is given to  the compiler and the compiler defaults to something older. This change enables C99 detection in CMake to match the behavior with autotools.

`CMAKE_C_STANDARD 99` is an equivalent of:
https://github.com/maxmind/libmaxminddb/blob/ed7a4252c8a2f19885479fe35ea9e8a12106a1ec/configure.ac#L21

`CMAKE_C_EXTENSIONS OFF` is an equivalent of:
https://github.com/maxmind/libmaxminddb/blob/ed7a4252c8a2f19885479fe35ea9e8a12106a1ec/configure.ac#L56