### PR TITLE
build: cmake: remove lib prefix on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,6 @@ if(WIN32)
   target_link_libraries(maxminddb ws2_32)
 endif()
 
-set(CMAKE_SHARED_LIBRARY_PREFIX lib)
-set(CMAKE_STATIC_LIBRARY_PREFIX lib)
-
 set(MAXMINDB_INCLUDE_DIR
   .
   include


### PR DESCRIPTION
`CMAKE_SHARED_LIBRARY_PREFIX` defaults to `lib` on UNIX systems but to an empty string on Windows which follows the conventions on these systems. The existing build forces the prefix on all platforms so the dynamic library produced by this setup on Windows will be `libmaxminddb.dll` (instead of `maxminddb.dll`).

This patch just removes the explicit configuration of the prefix so the dynamic library on Linux will be `libmaxminddb.so` and `maxminddb.dll` on Windows.

I'm not sure if this hard-coded prefix was intentional. I'm working on Conan package for libmaxmminddb and I have to include this patch to make linking work on Windows. It could be something specific to Conan though but I think the change makes sense.