### PR TITLE
build: cmake: fix target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,13 +59,9 @@ endif()
 set(CMAKE_SHARED_LIBRARY_PREFIX lib)
 set(CMAKE_STATIC_LIBRARY_PREFIX lib)
 
-set(MAXMINDB_INCLUDE_DIR
-  .
-  include
-)
-
 target_include_directories(maxminddb PUBLIC
-  $<BUILD_INTERFACE:${MAXMINDB_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
The `target_include_directories` option doesn't work as expected. I noticed that when trying to include the libmaxminddb as a CMake subdirectory into a different project.

Here is a simple reproducer:
```
project(reproducer)
add_subdirectory("libmaxminddb")
```

CMake will fail on building that project with the following error:
```
CMake Error in libmaxminddb/CMakeLists.txt:
  Target "maxminddb" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/tmp/repro/libmaxminddb/"

  which is prefixed in the build directory.
```

The problem seems to be two-fold:
- The variable in `$<BUILD_INTERFACE:${VAR}>` must be a single path.
- The paths provided for build interface must not be relative.

The attached patch fixes the problem.