### PR TITLE
build: cmake: fix installation of .dll files on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,7 @@ set(MAXMINDB_HEADERS
 set_target_properties(maxminddb PROPERTIES PUBLIC_HEADER "${MAXMINDB_HEADERS}")
 
 install(TARGETS maxminddb
-        EXPORT maxminddb
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/
-)
+	EXPORT maxminddb)
 
 # This is required to work with FetchContent
 install(EXPORT maxminddb


### PR DESCRIPTION
The .dll files are not installed on Windows when libmaxminddb is built as a shared library.

A shared on Windows consist of the `.dll` with the actual code and `.lib` with the description of symbols. Weirdly enough, the `.dll`s are installed into runtime directory and `.lib`s into the libraries directory.

The install target in CMake installs only `ARCHIVE` and `PUBLIC_HEADER` objects. To support Windows, it either needs to include `RUNTIME` as well or the install command doesn't need to list the objects types. This PR uses the later approach.