### PR TITLE
build: cmake: export all symbols on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ endif()
 
 if(WIN32)
   target_link_libraries(maxminddb ws2_32)
+  if(BUILD_SHARED_LIBS)
+    set_target_properties(maxminddb PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
 endif()
 
 target_include_directories(maxminddb PUBLIC


### PR DESCRIPTION
When build libmaxminddb as a dynamic library on Windows, the `.lib` file is not created as the symbols in the library are not annotated with `__declspec(dllimport)`. This can be workaround with `WINDOWS_EXPORT_ALL_SYMBOLS` CMake property.

Easiest workaround is to configure with `cmake -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON`.

This patch enables the above property on the `maxminddb` target only which seems to be a cleaner solution.