### PR TITLE
CMake: fix cross-build to iOS/tvOS/watchOS

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -8,6 +8,6 @@ if(NOT WIN32)
 
   install(
     TARGETS mmdblookup
-    RUNTIME DESTINATION bin
+    DESTINATION bin
   )
 endif()


### PR DESCRIPTION
If host is iOS/tvOS/watchOS, executables are BUNDLE and need a destination since https://cmake.org/cmake/help/latest/policy/CMP0006.html, otherwise CMake configuration fails.