### PR TITLE
autotools: Add proper linker flags for mingw

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -4,6 +4,10 @@ AM_LDFLAGS = $(top_builddir)/src/libmaxminddb.la
 
 bin_PROGRAMS = mmdblookup
 
+if WINDOWS
+AM_LDFLAGS += -municode
+endif
+
 if !WINDOWS
 AM_CPPFLAGS += -pthread
 AM_LDFLAGS += -pthread

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,10 @@ lib_LTLIBRARIES = libmaxminddb.la
 libmaxminddb_la_SOURCES = maxminddb.c maxminddb-compat-util.h \
 	data-pool.c data-pool.h
 libmaxminddb_la_LDFLAGS = -version-info 0:7:0 -export-symbols-regex '^MMDB_.*'
+if WINDOWS
+libmaxminddb_la_LDFLAGS += -no-undefined
+endif
+
 include_HEADERS = $(top_srcdir)/include/maxminddb.h
 
 pkgconfig_DATA = libmaxminddb.pc


### PR DESCRIPTION
* Add -no-undefined flag to build shared library, otherwise this error will show:
  libtool: warning: undefined symbols not allowed in x86_64-w64-mingw32 shared libraries; building static only

* Add -municode flag for wmain in mmdblookup program.