### PR TITLE
Make PACKAGE_VERSION a private macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(maxminddb::maxminddb ALIAS maxminddb)
 
 set_target_properties(maxminddb PROPERTIES VERSION ${MAXMINDDB_SOVERSION})
 
-target_compile_definitions(maxminddb PUBLIC PACKAGE_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(maxminddb PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
 
 if(NOT IS_BIG_ENDIAN)
   target_compile_definitions(maxminddb PRIVATE MMDB_LITTLE_ENDIAN=1)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -11,6 +11,8 @@ if(NOT MSVC)
     target_link_options(mmdblookup PRIVATE "-municode")
   endif()
 
+  target_compile_definitions(mmdblookup PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
+
   target_link_libraries(mmdblookup maxminddb pthread)
 
   install(

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -33,6 +33,7 @@ foreach(TEST_TARGET_NAME ${TEST_TARGET_NAMES})
   add_executable(${TEST_TARGET_NAME} ${TEST_TARGET_NAME}.c maxminddb_test_helper.c)
   target_include_directories(${TEST_TARGET_NAME} PRIVATE ../src)
   target_link_libraries(${TEST_TARGET_NAME} maxminddb tap)
+  target_compile_definitions(${TEST_TARGET_NAME} PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
 
   if(UNIX)
     target_link_libraries(${TEST_TARGET_NAME} m)


### PR DESCRIPTION
This macro won't be inherited from the command line, and only used internally inside libmaxmindb.

This is causing a warning that gets transformed in an error for us unfortunately as thrift also has an internal PACKAGE_VERSION macro, and both conflict as soon as we include thrift.h.