### PR TITLE
Set PACKAGE_VERSION in header file for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(maxminddb::maxminddb ALIAS maxminddb)
 
 set_target_properties(maxminddb PROPERTIES VERSION ${MAXMINDDB_SOVERSION})
 
-target_compile_definitions(maxminddb PUBLIC PACKAGE_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(maxminddb PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
 
 if(NOT IS_BIG_ENDIAN)
   target_compile_definitions(maxminddb PRIVATE MMDB_LITTLE_ENDIAN=1)

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## 1.7.2
+
+* `PACKAGE_VERSION` is now a private compile definition when building
+  with CMake. Pull request by bsergean. GitHub #308.
+
 ## 1.7.1 - 2022-09-30
 
 * The external symbols test now only runs on Linux. It assumes a Linux

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -11,6 +11,8 @@ if(NOT MSVC)
     target_link_options(mmdblookup PRIVATE "-municode")
   endif()
 
+  target_compile_definitions(mmdblookup PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
+
   target_link_libraries(mmdblookup maxminddb pthread)
 
   install(

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -28,7 +28,10 @@ extern "C" {
 #include <winsock2.h>
 #include <ws2tcpip.h>
 /* libmaxminddb package version from configure */
+#ifndef PACKAGE_VERSION
+/* This is used by msbuild. Once we delete those files, we can remove this. */
 #define PACKAGE_VERSION "1.7.1"
+#endif
 
 typedef ADDRESS_FAMILY sa_family_t;
 

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -33,6 +33,7 @@ foreach(TEST_TARGET_NAME ${TEST_TARGET_NAMES})
   add_executable(${TEST_TARGET_NAME} ${TEST_TARGET_NAME}.c maxminddb_test_helper.c)
   target_include_directories(${TEST_TARGET_NAME} PRIVATE ../src)
   target_link_libraries(${TEST_TARGET_NAME} maxminddb tap)
+  target_compile_definitions(${TEST_TARGET_NAME} PRIVATE PACKAGE_VERSION="${PROJECT_VERSION}")
 
   if(UNIX)
     target_link_libraries(${TEST_TARGET_NAME} m)


### PR DESCRIPTION
- Only set PACKAGE_VERSION on WIN32 if not set
- Define PACKAGE_VERSION in .in file for CMake
