### PR TITLE
Fix file generation error on multiple CMake configurations reload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
-configure_file(${PROJECT_SOURCE_DIR}/include/maxminddb_config.h.cmake.in 
-               ${PROJECT_SOURCE_DIR}/include/maxminddb_config.h)
+configure_file(${PROJECT_SOURCE_DIR}/include/maxminddb_config.h.cmake.in
+          ${CMAKE_CURRENT_BINARY_DIR}/generated/maxminddb_config.h)
 
 add_library(maxminddb
   src/maxminddb.c
@@ -79,12 +79,14 @@ endif()
 target_include_directories(maxminddb PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/>
   $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:generated>
 )
 
 set(MAXMINDB_HEADERS
   include/maxminddb.h
-  include/maxminddb_config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/generated/maxminddb_config.h
 )
 set_target_properties(maxminddb PROPERTIES PUBLIC_HEADER "${MAXMINDB_HEADERS}")
 


### PR DESCRIPTION
Propose to move generated file to binary directory because it creates from different CMake configuration at the same time and it is race condition

The problems occures when you have multiple CMake configurations for example Release, Relwithdebinfo, Debug.
And when you reload CMake at same time every configuration try to modify file in same location **maxminddb_config.h**.
So easiest fix is to move generated file per configuration.