### PR TITLE
Remove Windows sa_family_t typedef from public header

### DIFF
--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -17,8 +17,6 @@ extern "C" {
 #include <ws2tcpip.h>
 /* libmaxminddb package version from configure */
 
-typedef ADDRESS_FAMILY sa_family_t;
-
 #if defined(_MSC_VER)
 /* MSVC doesn't define signed size_t, copy it from configure */
 #define ssize_t SSIZE_T

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -23,6 +23,7 @@
 #endif
 #include <windows.h>
 #include <ws2ipdef.h>
+typedef ADDRESS_FAMILY sa_family_t;
 #else
 #include <arpa/inet.h>
 #include <sys/mman.h>


### PR DESCRIPTION
This typedef isn't needed in maxminddb.h since sa_family_t isn't part of this library's public API.  Moreover, it can conflict with typedefs in the headers of other libraries.  Move the typedef from maxminddb.h to maxminddb.c, where sa_family_t is used.

This change makes it possible to build [Zeek](https://github.com/zeek/zeek) with libmaxminddb on Windows using MSVC, something that currently fails because it depends on [libunistd](https://github.com/robinrowe/libunistd) and that also defines sa_family_t.