### PR TITLE
Make greater use of GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,9 @@ endif()
 # Generate libmaxminddb.pc file for pkg-config
 # Set the required variables as same with autotools
 set(prefix ${CMAKE_INSTALL_PREFIX})
-set(exec_prefix \${prefix})
-set(libdir \${exec_prefix}/lib)
-set(includedir \${prefix}/include)
+set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${CMAKE_INSTALL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_INCLUDEDIR})
 set(PACKAGE_VERSION ${maxminddb_VERSION})
 
 if (MAXMINDDB_INSTALL)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT MSVC)
   if (MAXMINDDB_INSTALL)
     install(
       TARGETS mmdblookup
-      DESTINATION bin
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
   endif()
 endif()


### PR DESCRIPTION
Actually use the defined variables in the pkg-config file, as well as for installing the `mmdblookup` binary.