### PR TITLE
Fix Build issues from using vcpkg port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ target_include_directories(maxminddb PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/>
   $<INSTALL_INTERFACE:include>
-  $<INSTALL_INTERFACE:generated>
 )
 
 set(MAXMINDB_HEADERS


### PR DESCRIPTION
Using the maxminddb vcpkg port causes a unnecessary include to a private build "generated" folder that is found when using pre-built vcpkg libraries in another project