### PR TITLE
fix: memory leak in MMDB_open()

### DIFF
--- a/t/bad_pointers_t.c
+++ b/t/bad_pointers_t.c
@@ -28,8 +28,6 @@ void run_tests(int mode, const char *mode_desc) {
                MMDB_INVALID_DATA_ERROR,
                "MMDB_get_entry_data_list returns MMDB_INVALID_DATA_ERROR for "
                "bad pointer in data section");
-
-        MMDB_free_entry_data_list(entry_data_list);
     }
 
     {


### PR DESCRIPTION
While I was fuzzing, I found a total of three memory leaks. This is the patch.
