### PR TITLE
Set entry parameter to NULL or valid memory

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,15 @@
+## 1.12.2
+
+* `MMDB_get_entry_data_list()` now always sets the passed `entry_data_list`
+  parameter to either `NULL` or valid memory. This makes it safe for
+  callers to use `MMDB_free_entry_data_list()` on it even in case of error.
+  In 1.12.0 `MMDB_get_entry_data_list()` was changed to not set this
+  parameter to valid memory in additional error cases. That change caused
+  segfaults for certain libraries that assumed it was safe to free memory
+  on error. Doing so was never safe, but worked in some cases. This change
+  makes such calls safe. Reported by Petr Pisar. GitHub
+  maxmind/MaxMind-DB-Reader-XS#39.
+
 ## 1.12.1 - 2025-01-08
 
 * Added missing `cmake_uninstall.cmake.in` to the source distribution. This

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1636,6 +1636,8 @@ int MMDB_get_metadata_as_entry_data_list(
 
 int MMDB_get_entry_data_list(MMDB_entry_s *start,
                              MMDB_entry_data_list_s **const entry_data_list) {
+    *entry_data_list = NULL;
+
     MMDB_data_pool_s *const pool = data_pool_new(MMDB_POOL_INIT_SIZE);
     if (!pool) {
         return MMDB_OUT_OF_MEMORY_ERROR;

--- a/t/bad_pointers_t.c
+++ b/t/bad_pointers_t.c
@@ -28,6 +28,11 @@ void run_tests(int mode, const char *mode_desc) {
                MMDB_INVALID_DATA_ERROR,
                "MMDB_get_entry_data_list returns MMDB_INVALID_DATA_ERROR for "
                "bad pointer in data section");
+
+        // This is not necessary as on error we should not need to free
+        // anything. However test that it is safe to do so. See change in
+        // 1.12.2.
+        MMDB_free_entry_data_list(entry_data_list);
     }
 
     {


### PR DESCRIPTION
To avoid segfaults in callers that freed the parameter on error.