### PR TITLE
Remove __restrict override for MSVC

### DIFF
--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -21,8 +21,6 @@ extern "C" {
 /* MSVC doesn't define signed size_t, copy it from configure */
 #define ssize_t SSIZE_T
 
-/* MSVC doesn't support restricted pointers */
-#define restrict
 #endif
 #else
 #include <netdb.h>


### PR DESCRIPTION
The library disables the restrict keyword when building with MSVC:
https://github.com/maxmind/libmaxminddb/blob/bbbfd1f4f9b3f706fdcd3f4c23b8f6e30276df8d/include/maxminddb.h#L24-L25

MSVC has supported the restrict keyword since 2015:
https://learn.microsoft.com/en-us/cpp/cpp/extension-restrict?view=msvc-170

This PR removes the legacy define allowing builds with MSVC to use the restrict keyword.