### PR TITLE
Fix warnings in float/double functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,4 @@ IndentWidth: 4
 BinPackArguments: false
 BinPackParameters: false
 IndentCaseLabels: true
+IndentPPDirectives: BeforeHash

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## 1.13.0
+
+* The handling of float and double types was rewritten to fix compiler errors
+  and to eliminate the use of volatile.
+
 ## 1.12.2 - 2025-01-10
 
 * `MMDB_get_entry_data_list()` now always sets the passed `entry_data_list`

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 
 * The handling of float and double types was rewritten to fix compiler errors
   and to eliminate the use of volatile.
+* Improved endian preprocessor check if `MMDB_LITTLE_ENDIAN` is not set.
 
 ## 1.12.2 - 2025-01-10
 

--- a/bin/mmdblookup.c
+++ b/bin/mmdblookup.c
@@ -1,15 +1,15 @@
 #ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
+    #define _POSIX_C_SOURCE 200809L
 #endif
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+    #include <config.h>
 #endif
 #include "maxminddb.h"
 #include <errno.h>
 #include <getopt.h>
 #ifndef _WIN32
-#include <pthread.h>
+    #include <pthread.h>
 #endif
 #include <limits.h>
 #include <stdbool.h>
@@ -19,13 +19,13 @@
 #include <time.h>
 
 #ifdef _WIN32
-#ifndef UNICODE
-#define UNICODE
-#endif
-#include <malloc.h>
+    #ifndef UNICODE
+        #define UNICODE
+    #endif
+    #include <malloc.h>
 #else
-#include <libgen.h>
-#include <unistd.h>
+    #include <libgen.h>
+    #include <unistd.h>
 #endif
 
 static void usage(char *program, int exit_code, const char *error);
@@ -718,28 +718,28 @@ static bool start_threaded_benchmark(MMDB_s *const mmdb,
 
 static long double get_time(void) {
     // clock_gettime() is not present on OSX until 10.12.
-#ifdef HAVE_CLOCK_GETTIME
+    #ifdef HAVE_CLOCK_GETTIME
     struct timespec tp = {
         .tv_sec = 0,
         .tv_nsec = 0,
     };
     clockid_t clk_id = CLOCK_REALTIME;
-#ifdef _POSIX_MONOTONIC_CLOCK
+        #ifdef _POSIX_MONOTONIC_CLOCK
     clk_id = CLOCK_MONOTONIC;
-#endif
+        #endif
     if (clock_gettime(clk_id, &tp) != 0) {
         fprintf(stderr, "clock_gettime(): %s\n", strerror(errno));
         return -1;
     }
     return (long double)tp.tv_sec + ((float)tp.tv_nsec / 1e9);
-#else
+    #else
     time_t t = time(NULL);
     if (t == (time_t)-1) {
         fprintf(stderr, "time(): %s\n", strerror(errno));
         return -1;
     }
     return (long double)t;
-#endif
+    #endif
 }
 
 static void *thread(void *arg) {

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -12,6 +12,14 @@ extern "C" {
 #include <stdio.h>
 #include <sys/types.h>
 
+#ifdef __has_include
+#if __has_include(<endian.h>)
+#include <endian.h>
+#elif __has_include(<sys/endian.h>)
+#include <sys/endian.h>
+#endif
+#endif
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -26,6 +34,17 @@ extern "C" {
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#endif
+
+#if !defined(MMDB_LITTLE_ENDIAN)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MMDB_LITTLE_ENDIAN 1
+#endif
+#elif defined(_WIN32) || defined(_WIN64)
+// We assume modern Windows targets are little endian
+#define MMDB_LITTLE_ENDIAN 1
+#endif
 #endif
 
 #define MMDB_DATA_TYPE_EXTENDED (0)

--- a/include/maxminddb.h
+++ b/include/maxminddb.h
@@ -3,97 +3,97 @@ extern "C" {
 #endif
 
 #ifndef MAXMINDDB_H
-#define MAXMINDDB_H
+    #define MAXMINDDB_H
 
-#include "maxminddb_config.h"
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <sys/types.h>
+    #include "maxminddb_config.h"
+    #include <stdarg.h>
+    #include <stdbool.h>
+    #include <stdint.h>
+    #include <stdio.h>
+    #include <sys/types.h>
 
-#ifdef __has_include
-#if __has_include(<endian.h>)
-#include <endian.h>
-#elif __has_include(<sys/endian.h>)
-#include <sys/endian.h>
-#endif
-#endif
+    #ifdef __has_include
+        #if __has_include(<endian.h>)
+            #include <endian.h>
+        #elif __has_include(<sys/endian.h>)
+            #include <sys/endian.h>
+        #endif
+    #endif
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-/* libmaxminddb package version from configure */
+    #ifdef _WIN32
+        #include <winsock2.h>
+        #include <ws2tcpip.h>
+    /* libmaxminddb package version from configure */
 
-#if defined(_MSC_VER)
-/* MSVC doesn't define signed size_t, copy it from configure */
-#define ssize_t SSIZE_T
+        #if defined(_MSC_VER)
+            /* MSVC doesn't define signed size_t, copy it from configure */
+            #define ssize_t SSIZE_T
 
-#endif
-#else
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#endif
+        #endif
+    #else
+        #include <netdb.h>
+        #include <netinet/in.h>
+        #include <sys/socket.h>
+    #endif
 
-#if !defined(MMDB_LITTLE_ENDIAN)
-#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define MMDB_LITTLE_ENDIAN 1
-#endif
-#elif defined(_WIN32) || defined(_WIN64)
-// We assume modern Windows targets are little endian
-#define MMDB_LITTLE_ENDIAN 1
-#endif
-#endif
+    #if !defined(MMDB_LITTLE_ENDIAN)
+        #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+            #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+                #define MMDB_LITTLE_ENDIAN 1
+            #endif
+        #elif defined(_WIN32) || defined(_WIN64)
+            // We assume modern Windows targets are little endian
+            #define MMDB_LITTLE_ENDIAN 1
+        #endif
+    #endif
 
-#define MMDB_DATA_TYPE_EXTENDED (0)
-#define MMDB_DATA_TYPE_POINTER (1)
-#define MMDB_DATA_TYPE_UTF8_STRING (2)
-#define MMDB_DATA_TYPE_DOUBLE (3)
-#define MMDB_DATA_TYPE_BYTES (4)
-#define MMDB_DATA_TYPE_UINT16 (5)
-#define MMDB_DATA_TYPE_UINT32 (6)
-#define MMDB_DATA_TYPE_MAP (7)
-#define MMDB_DATA_TYPE_INT32 (8)
-#define MMDB_DATA_TYPE_UINT64 (9)
-#define MMDB_DATA_TYPE_UINT128 (10)
-#define MMDB_DATA_TYPE_ARRAY (11)
-#define MMDB_DATA_TYPE_CONTAINER (12)
-#define MMDB_DATA_TYPE_END_MARKER (13)
-#define MMDB_DATA_TYPE_BOOLEAN (14)
-#define MMDB_DATA_TYPE_FLOAT (15)
+    #define MMDB_DATA_TYPE_EXTENDED (0)
+    #define MMDB_DATA_TYPE_POINTER (1)
+    #define MMDB_DATA_TYPE_UTF8_STRING (2)
+    #define MMDB_DATA_TYPE_DOUBLE (3)
+    #define MMDB_DATA_TYPE_BYTES (4)
+    #define MMDB_DATA_TYPE_UINT16 (5)
+    #define MMDB_DATA_TYPE_UINT32 (6)
+    #define MMDB_DATA_TYPE_MAP (7)
+    #define MMDB_DATA_TYPE_INT32 (8)
+    #define MMDB_DATA_TYPE_UINT64 (9)
+    #define MMDB_DATA_TYPE_UINT128 (10)
+    #define MMDB_DATA_TYPE_ARRAY (11)
+    #define MMDB_DATA_TYPE_CONTAINER (12)
+    #define MMDB_DATA_TYPE_END_MARKER (13)
+    #define MMDB_DATA_TYPE_BOOLEAN (14)
+    #define MMDB_DATA_TYPE_FLOAT (15)
 
-#define MMDB_RECORD_TYPE_SEARCH_NODE (0)
-#define MMDB_RECORD_TYPE_EMPTY (1)
-#define MMDB_RECORD_TYPE_DATA (2)
-#define MMDB_RECORD_TYPE_INVALID (3)
+    #define MMDB_RECORD_TYPE_SEARCH_NODE (0)
+    #define MMDB_RECORD_TYPE_EMPTY (1)
+    #define MMDB_RECORD_TYPE_DATA (2)
+    #define MMDB_RECORD_TYPE_INVALID (3)
 
-/* flags for open */
-#define MMDB_MODE_MMAP (1)
-#define MMDB_MODE_MASK (7)
+    /* flags for open */
+    #define MMDB_MODE_MMAP (1)
+    #define MMDB_MODE_MASK (7)
 
-/* error codes */
-#define MMDB_SUCCESS (0)
-#define MMDB_FILE_OPEN_ERROR (1)
-#define MMDB_CORRUPT_SEARCH_TREE_ERROR (2)
-#define MMDB_INVALID_METADATA_ERROR (3)
-#define MMDB_IO_ERROR (4)
-#define MMDB_OUT_OF_MEMORY_ERROR (5)
-#define MMDB_UNKNOWN_DATABASE_FORMAT_ERROR (6)
-#define MMDB_INVALID_DATA_ERROR (7)
-#define MMDB_INVALID_LOOKUP_PATH_ERROR (8)
-#define MMDB_LOOKUP_PATH_DOES_NOT_MATCH_DATA_ERROR (9)
-#define MMDB_INVALID_NODE_NUMBER_ERROR (10)
-#define MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR (11)
+    /* error codes */
+    #define MMDB_SUCCESS (0)
+    #define MMDB_FILE_OPEN_ERROR (1)
+    #define MMDB_CORRUPT_SEARCH_TREE_ERROR (2)
+    #define MMDB_INVALID_METADATA_ERROR (3)
+    #define MMDB_IO_ERROR (4)
+    #define MMDB_OUT_OF_MEMORY_ERROR (5)
+    #define MMDB_UNKNOWN_DATABASE_FORMAT_ERROR (6)
+    #define MMDB_INVALID_DATA_ERROR (7)
+    #define MMDB_INVALID_LOOKUP_PATH_ERROR (8)
+    #define MMDB_LOOKUP_PATH_DOES_NOT_MATCH_DATA_ERROR (9)
+    #define MMDB_INVALID_NODE_NUMBER_ERROR (10)
+    #define MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR (11)
 
-#if !(MMDB_UINT128_IS_BYTE_ARRAY)
-#if MMDB_UINT128_USING_MODE
+    #if !(MMDB_UINT128_IS_BYTE_ARRAY)
+        #if MMDB_UINT128_USING_MODE
 typedef unsigned int mmdb_uint128_t __attribute__((__mode__(TI)));
-#else
+        #else
 typedef unsigned __int128 mmdb_uint128_t;
-#endif
-#endif
+        #endif
+    #endif
 
 /* This is a pointer into the data section for a given IP address lookup */
 typedef struct MMDB_entry_s {
@@ -118,11 +118,11 @@ typedef struct MMDB_entry_data_s {
         uint32_t uint32;
         int32_t int32;
         uint64_t uint64;
-#if MMDB_UINT128_IS_BYTE_ARRAY
+    #if MMDB_UINT128_IS_BYTE_ARRAY
         uint8_t uint128[16];
-#else
+    #else
         mmdb_uint128_t uint128;
-#endif
+    #endif
         bool boolean;
         float float_value;
     };

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1,9 +1,9 @@
 #ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
+    #define _POSIX_C_SOURCE 200809L
 #endif
 
 #if HAVE_CONFIG_H
-#include <config.h>
+    #include <config.h>
 #endif
 #include "data-pool.h"
 #include "maxminddb-compat-util.h"
@@ -18,43 +18,43 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
-#ifndef UNICODE
-#define UNICODE
-#endif
-#include <windows.h>
-#include <ws2ipdef.h>
-#ifndef SSIZE_MAX
-#define SSIZE_MAX INTPTR_MAX
-#endif
+    #ifndef UNICODE
+        #define UNICODE
+    #endif
+    #include <windows.h>
+    #include <ws2ipdef.h>
+    #ifndef SSIZE_MAX
+        #define SSIZE_MAX INTPTR_MAX
+    #endif
 typedef ADDRESS_FAMILY sa_family_t;
 #else
-#include <arpa/inet.h>
-#include <sys/mman.h>
-#include <unistd.h>
+    #include <arpa/inet.h>
+    #include <sys/mman.h>
+    #include <unistd.h>
 #endif
 
 #define MMDB_DATA_SECTION_SEPARATOR (16)
 #define MAXIMUM_DATA_STRUCTURE_DEPTH (512)
 
 #ifdef MMDB_DEBUG
-#define DEBUG_MSG(msg) fprintf(stderr, msg "\n")
-#define DEBUG_MSGF(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
-#define DEBUG_BINARY(fmt, byte)                                                \
-    do {                                                                       \
-        char *binary = byte_to_binary(byte);                                   \
-        if (NULL == binary) {                                                  \
-            fprintf(stderr, "Calloc failed in DEBUG_BINARY\n");                \
-            abort();                                                           \
-        }                                                                      \
-        fprintf(stderr, fmt "\n", binary);                                     \
-        free(binary);                                                          \
-    } while (0)
-#define DEBUG_NL fprintf(stderr, "\n")
+    #define DEBUG_MSG(msg) fprintf(stderr, msg "\n")
+    #define DEBUG_MSGF(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
+    #define DEBUG_BINARY(fmt, byte)                                            \
+        do {                                                                   \
+            char *binary = byte_to_binary(byte);                               \
+            if (NULL == binary) {                                              \
+                fprintf(stderr, "Calloc failed in DEBUG_BINARY\n");            \
+                abort();                                                       \
+            }                                                                  \
+            fprintf(stderr, fmt "\n", binary);                                 \
+            free(binary);                                                      \
+        } while (0)
+    #define DEBUG_NL fprintf(stderr, "\n")
 #else
-#define DEBUG_MSG(...)
-#define DEBUG_MSGF(...)
-#define DEBUG_BINARY(...)
-#define DEBUG_NL
+    #define DEBUG_MSG(...)
+    #define DEBUG_MSGF(...)
+    #define DEBUG_BINARY(...)
+    #define DEBUG_NL
 #endif
 
 #ifdef MMDB_DEBUG
@@ -116,12 +116,12 @@ char *type_num_to_name(uint8_t num) {
  * platforms where SIZE_MAX is a 64-bit integer, this would be a no-op, and it
  * makes the compiler complain if we do the check anyway. */
 #if SIZE_MAX == UINT32_MAX
-#define MAYBE_CHECK_SIZE_OVERFLOW(lhs, rhs, error)                             \
-    if ((lhs) > (rhs)) {                                                       \
-        return error;                                                          \
-    }
+    #define MAYBE_CHECK_SIZE_OVERFLOW(lhs, rhs, error)                         \
+        if ((lhs) > (rhs)) {                                                   \
+            return error;                                                      \
+        }
 #else
-#define MAYBE_CHECK_SIZE_OVERFLOW(...)
+    #define MAYBE_CHECK_SIZE_OVERFLOW(...)
 #endif
 
 typedef struct record_info_s {
@@ -428,21 +428,21 @@ static int map_file(MMDB_s *const mmdb) {
     int status = MMDB_SUCCESS;
 
     int o_flags = O_RDONLY;
-#ifdef O_CLOEXEC
+    #ifdef O_CLOEXEC
     o_flags |= O_CLOEXEC;
-#endif
+    #endif
     int fd = open(mmdb->filename, o_flags);
     if (fd < 0) {
         status = MMDB_FILE_OPEN_ERROR;
         goto cleanup;
     }
 
-#if defined(FD_CLOEXEC) && !defined(O_CLOEXEC)
+    #if defined(FD_CLOEXEC) && !defined(O_CLOEXEC)
     int fd_flags = fcntl(fd, F_GETFD);
     if (fd_flags >= 0) {
         fcntl(fd, F_SETFD, fd_flags | FD_CLOEXEC);
     }
-#endif
+    #endif
 
     struct stat s;
     if (fstat(fd, &s)) {
@@ -1768,7 +1768,7 @@ static int get_entry_data_list(const MMDB_s *const mmdb,
 }
 
 #ifndef __has_builtin
-#define __has_builtin(x) 0
+    #define __has_builtin(x) 0
 #endif
 
 static inline uint32_t bswap32(uint32_t x) {
@@ -1866,14 +1866,14 @@ static void free_mmdb_struct(MMDB_s *const mmdb) {
 
     if (NULL != mmdb->filename) {
 #if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
+    // This is a const char * that we need to free, which isn't valid. However
+    // it would mean changing the public API to fix this.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-qual"
 #endif
         FREE_AND_SET_NULL(mmdb->filename);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
     }
     if (NULL != mmdb->file_content) {
@@ -1883,29 +1883,29 @@ static void free_mmdb_struct(MMDB_s *const mmdb) {
          * to cleanup then. */
         WSACleanup();
 #else
-#if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-#endif
+    #if defined(__clang__)
+        // This is a const char * that we need to free, which isn't valid.
+        // However it would mean changing the public API to fix this.
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wcast-qual"
+    #endif
         munmap((void *)mmdb->file_content, (size_t)mmdb->file_size);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #endif
 #endif
     }
 
     if (NULL != mmdb->metadata.database_type) {
 #if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
+    // This is a const char * that we need to free, which isn't valid. However
+    // it would mean changing the public API to fix this.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-qual"
 #endif
         FREE_AND_SET_NULL(mmdb->metadata.database_type);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
     }
 
@@ -1920,14 +1920,14 @@ static void free_languages_metadata(MMDB_s *mmdb) {
 
     for (size_t i = 0; i < mmdb->metadata.languages.count; i++) {
 #if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
+    // This is a const char * that we need to free, which isn't valid. However
+    // it would mean changing the public API to fix this.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-qual"
 #endif
         FREE_AND_SET_NULL(mmdb->metadata.languages.names[i]);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
     }
     FREE_AND_SET_NULL(mmdb->metadata.languages.names);
@@ -1942,30 +1942,30 @@ static void free_descriptions_metadata(MMDB_s *mmdb) {
         if (NULL != mmdb->metadata.description.descriptions[i]) {
             if (NULL != mmdb->metadata.description.descriptions[i]->language) {
 #if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
+    // This is a const char * that we need to free, which isn't valid. However
+    // it would mean changing the public API to fix this.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-qual"
 #endif
                 FREE_AND_SET_NULL(
                     mmdb->metadata.description.descriptions[i]->language);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
             }
 
             if (NULL !=
                 mmdb->metadata.description.descriptions[i]->description) {
 #if defined(__clang__)
-// This is a const char * that we need to free, which isn't valid. However it
-// would mean changing the public API to fix this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
+    // This is a const char * that we need to free, which isn't valid. However
+    // it would mean changing the public API to fix this.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-qual"
 #endif
                 FREE_AND_SET_NULL(
                     mmdb->metadata.description.descriptions[i]->description);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
             }
             FREE_AND_SET_NULL(mmdb->metadata.description.descriptions[i]);

--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -1803,9 +1803,7 @@ static float get_ieee754_float(const uint8_t *restrict p) {
 
     memcpy(&i, p, sizeof(uint32_t));
 
-/* Windows builds don't use autoconf but we can assume they're all
- * little-endian. */
-#if MMDB_LITTLE_ENDIAN || _WIN32
+#if MMDB_LITTLE_ENDIAN
     i = bswap32(i);
 #endif
 
@@ -1820,7 +1818,7 @@ static double get_ieee754_double(const uint8_t *restrict p) {
 
     memcpy(&i, p, sizeof(uint64_t));
 
-#if MMDB_LITTLE_ENDIAN || _WIN32
+#if MMDB_LITTLE_ENDIAN
     i = bswap64(i);
 #endif
 

--- a/t/maxminddb_test_helper.c
+++ b/t/maxminddb_test_helper.c
@@ -1,7 +1,7 @@
 #include "maxminddb_test_helper.h"
 
 #if HAVE_CONFIG_H
-#include <config.h>
+    #include <config.h>
 #endif
 
 #include <assert.h>
@@ -11,10 +11,10 @@
 #include "maxminddb.h"
 
 #ifdef _WIN32
-#include <io.h>
+    #include <io.h>
 #else
-#include <libgen.h>
-#include <unistd.h>
+    #include <libgen.h>
+    #include <unistd.h>
 #endif
 
 void for_all_record_sizes(const char *filename_fmt,
@@ -27,13 +27,13 @@ void for_all_record_sizes(const char *filename_fmt,
 
         char filename[500];
 #if defined(__clang__)
-// This warning seems ok to ignore here in the tests.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
+    // This warning seems ok to ignore here in the tests.
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
         snprintf(filename, 500, filename_fmt, size);
 #if defined(__clang__)
-#pragma clang diagnostic pop
+    #pragma clang diagnostic pop
 #endif
 
         char description[14];

--- a/t/maxminddb_test_helper.h
+++ b/t/maxminddb_test_helper.h
@@ -2,11 +2,11 @@
 // this is test code, it should be fine to set it here. Setting it here avoids
 // setting it in every test program.
 #ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
+    #define _POSIX_C_SOURCE 200809L
 #endif
 
 #if HAVE_CONFIG_H
-#include <config.h>
+    #include <config.h>
 #endif
 #include "libtap/tap.h"
 #include "maxminddb-compat-util.h"
@@ -16,31 +16,31 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
 
-#define R_OK 4
+    #define R_OK 4
 
 #else
-#include <netdb.h>
+    #include <netdb.h>
 #endif
 
 #if defined _MSC_VER && _MSC_VER < 1900
-/* _snprintf has security issues, but I don't think it is worth
-   worrying about for the unit tests. */
-#define snprintf _snprintf
+    /* _snprintf has security issues, but I don't think it is worth
+       worrying about for the unit tests. */
+    #define snprintf _snprintf
 #endif
 
 #ifndef MMDB_TEST_HELPER_C
-#define MMDB_TEST_HELPER_C (1)
+    #define MMDB_TEST_HELPER_C (1)
 
-#ifdef __GNUC__
-#define UNUSED(x) UNUSED_##x __attribute__((__unused__))
-#else
-#define UNUSED
-#endif
+    #ifdef __GNUC__
+        #define UNUSED(x) UNUSED_##x __attribute__((__unused__))
+    #else
+        #define UNUSED
+    #endif
 
-#define MAX_DESCRIPTION_LENGTH 500
+    #define MAX_DESCRIPTION_LENGTH 500
 
 extern void for_all_record_sizes(const char *filename_fmt,
                                  void (*tests)(int record_size,


### PR DESCRIPTION
- **Do not rely on volatile for double/float decoding**
- **Improve endian check if macro is not set**
