### PR TITLE
Update PPA docs link to its canonical destination

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -20,8 +20,8 @@ You may want to refer to the section about prerequisites.
 In order to upload a PPA, you have to create a launchpad.net account and
 register a GPG key with that account. You also need to be added to the MaxMind
 team. Ask in the dev channel for someone to add you. See
-https://ubuntu.com/docs/launchpad/user/reference/packaging/ppas/ppa/
-for more details.
+https://ubuntu.com/docs/launchpad/user/reference/packaging/ppas/ppa/ for more
+details.
 
 The PPA release script is at `dev-bin/ppa-release.sh`. Running it should guide
 you though the release, although it may require some changes to run on

--- a/README.dev.md
+++ b/README.dev.md
@@ -20,7 +20,7 @@ You may want to refer to the section about prerequisites.
 In order to upload a PPA, you have to create a launchpad.net account and
 register a GPG key with that account. You also need to be added to the MaxMind
 team. Ask in the dev channel for someone to add you. See
-https://documentation.ubuntu.com/launchpad/user/reference/packaging/ppas/ppa/
+https://ubuntu.com/docs/launchpad/user/reference/packaging/ppas/ppa/
 for more details.
 
 The PPA release script is at `dev-bin/ppa-release.sh`. Running it should guide


### PR DESCRIPTION
## Summary

The Links workflow [failed](https://github.com/maxmind/libmaxminddb/actions/runs/28379093907/job/84076511416) because the Launchpad PPA documentation URL in `README.dev.md` now 301-redirects:

```
https://documentation.ubuntu.com/launchpad/user/reference/packaging/ppas/ppa/
  -> https://ubuntu.com/docs/launchpad/user/reference/packaging/ppas/ppa/
```

Since `lychee.toml` sets `max_redirects = 0` (so moved links get surfaced and updated to their canonical destination), this fails CI. This updates the link to the canonical `ubuntu.com/docs` URL, which returns 200 with no further redirect.

## Test plan

- `lychee --no-progress './README.dev.md'` → 3 OK, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the PPA documentation link in the developer README to point to the current Ubuntu docs page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->