### PR TITLE
Remove stale maxmind-db entry from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "maxmind-db"]
-	path = maxmind-db
-	url = https://github.com/maxmind/MaxMind-DB.git
 [submodule "t/libtap"]
 	path = t/libtap
 	url = https://github.com/zorgnax/libtap.git


### PR DESCRIPTION
## Problem

The Dependabot Failure Watcher failed ([run 31018162189](https://github.com/maxmind/libmaxminddb/actions/runs/31018162189)) because the first scheduled gitsubmodule update run ([run 30941152746](https://github.com/maxmind/libmaxminddb/actions/runs/30941152746), enabled in #465) aborted with:

```
dependency_file_not_found: "maxmind-db not found", file-path: "maxmind-db"
```

`.gitmodules` declared three submodules, but the repo tree only contains two gitlinks (`t/libtap` and `t/maxmind-db`). Commit 5f499c1 (2014) moved the submodule from `maxmind-db` to `t/maxmind-db` but left the old `[submodule "maxmind-db"]` stanza behind. Dependabot fetches each declared path via the GitHub contents API; `GET /contents/maxmind-db` returns 404, aborting the whole job.

## Fix

Remove the stale stanza. Nothing references a top-level `maxmind-db` checkout (the `t/Makefile.am` reference is relative to `t/`).

## Verification

Replicating Dependabot's per-path contents API lookup (the exact request that failed in the job log):

On main (`5886ccf`):
```
maxmind-db   -> HTTP 404   <- aborts the Dependabot job
t/libtap     -> 200
t/maxmind-db -> 200
```

On this branch (`8c33c0c`):
```
t/libtap     -> 200
t/maxmind-db -> 200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete submodule configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->