### PR TITLE
Fix signedness warning in data section size check (fixes #486)

### DIFF
--- a/src/maxminddb.c
+++ b/src/maxminddb.c
@@ -367,7 +367,7 @@ int MMDB_open(const char *const filename, uint32_t flags, MMDB_s *const mmdb) {
     }
     ssize_t data_section_size =
         mmdb->file_size - search_tree_size - MMDB_DATA_SECTION_SEPARATOR;
-    if (data_section_size > UINT32_MAX || data_section_size <= 0) {
+    if (data_section_size <= 0 || (uint64_t)data_section_size > UINT32_MAX) {
         status = MMDB_INVALID_METADATA_ERROR;
         goto cleanup;
     }


### PR DESCRIPTION
Fix a `-Wsign-compare` warning in the data section size check:

```
src/maxminddb.c:370:27: error: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘int’} and ‘unsigned int’ [-Werror=sign-compare]
```

`data_section_size` is a `ssize_t`, while `UINT32_MAX` is unsigned. The check is adjusted to avoid the signed/unsigned comparison. For consistency, the <= 0 check is performed first so the value is known to be positive before converting it to `uint64_t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered validation checks for data section size without changing behavior, error handling, or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->